### PR TITLE
Fix tagcloud rendering behaviour on special and wikipages

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,11 @@
 These are the release notes for the [Semantic Result Formats]
 (https://semantic-mediawiki.org/wiki/Semantic_Result_Formats) MediaWiki extension.
 
+## SRF 1.9.0.1 (2014-01-17)
+
+### Bug fixes
+
+* (#7) Fix tagcloud rendering on special pages and when using templates
 
 ## SRF 1.9 (2014-01-10)
 

--- a/formats/tagcloud/TagCloud.php
+++ b/formats/tagcloud/TagCloud.php
@@ -77,9 +77,7 @@ class TagCloud extends ResultPrinter {
 
 		// Template support
 		$this->hasTemplates = $this->params['template'] !== '';
-
-		// Prioritize HTML setting
-		$this->isHTML = $this->params['widget'] !== '' && $this->params['template'] === '';
+		$this->isHTML = $this->getTitle()->isSpecialPage() && !$this->hasTemplates;
 
 		// Register RL module
 		if ( in_array( $this->params['widget'], array( 'sphere', 'wordcloud' ) ) ) {


### PR DESCRIPTION
Additional content parsing is influenced by special page/template status.

An eyeball check on the following options (format=tagcloud):

1 link=all
2 link=none
3 template=TagCloud / link=none
4 template=TagCloud / link=all
5 widget=wordcloud / link=none
6 widget=wordcloud / link=all
7 widget=wordcloud / template=TagCloud
8 widget=sphere / link=none
9 widget=sphere / link=all
10 widget=sphere / template=TagCloud
