### PR TITLE
fixed bug with mainlabel causing duplicate headers in excel format.

### DIFF
--- a/formats/excel/SRF_Excel.php
+++ b/formats/excel/SRF_Excel.php
@@ -15,6 +15,21 @@ class SRFExcel extends SMWExportPrinter {
 	const HEADER_ROW_OFFSET = 1;
 
 	/**
+	 * @var int
+	 */
+	protected $rowNum;
+
+	/**
+	 * @var int
+	 */
+	protected $colNum;
+
+	/**
+	 * @var \PHPExcel_Worksheet
+	 */
+	protected $sheet;
+
+	/**
 	 * Some printers do not mainly produce embeddable HTML or Wikitext, but
 	 * produce stand-alone files. An example is RSS or iCalendar. This function
 	 * returns the mimetype string that this file would have, or FALSE if no
@@ -47,6 +62,14 @@ class SRFExcel extends SMWExportPrinter {
 		}
 	}
 
+	public function getParamDefinitions ( array $definitions ) {
+		$params = parent::getParamDefinitions( $definitions );
+
+		$definitions[ 'searchlabel' ]->setDefault( wfMessage( 'srf-excel-link' )->inContentLanguage()->text() );
+
+		return $params;
+	}
+
 	/**
 	 * Return serialised results in specified format.
 	 * Implemented by subclasses.
@@ -55,17 +78,17 @@ class SRFExcel extends SMWExportPrinter {
 		if ( $outputmode == SMW_OUTPUT_FILE ) {
 			if ( $this->isPHPExcelInstalled() ) {
 				$document = $this->createExcelDocument();
-				$sheet = $document->getSheet( 0 );
+				$this->sheet = $document->getSheet( 0 );
 
-				$rowNum = 0;
+				$this->rowNum = 0;
 				//Get headers
 				if ( $this->mShowHeaders ) {
-					$this->populateDocumentWithHeaders( $res, $sheet );
-					$rowNum++;
+					$this->populateDocumentWithHeaders( $res );
+					$this->rowNum++;
 				}
 
 				//Get data rows
-				$this->populateDocumentWithQueryData( $res, $sheet, $rowNum );
+				$this->populateDocumentWithQueryData( $res );
 
 				$result = $this->writeDocumentToString( $document );
 			} else {
@@ -93,36 +116,13 @@ class SRFExcel extends SMWExportPrinter {
 	/**
 	 * Populates the PHPExcel document with the query data
 	 *
-	 * @param $res       SMWQueryResult the query result
-	 * @param $sheet     \PHPExcel_Worksheet the current phpexcel sheet
-	 * @param $rowOffset int the offset at which rows should be inserted
+	 * @param $res SMWQueryResult the query result
 	 */
-	protected function populateDocumentWithQueryData ( $res, $sheet, $rowOffset ) {
+	protected function populateDocumentWithQueryData ( $res ) {
 		while ( $row = $res->getNext() ) {
-			$rowOffset++;
-			$colOffset = 0;
-			foreach ( $row as $field ) {
-				if($this->skipExtraMainLabel($field->getPrintRequest()->getLabel())){
-					continue;
-				}
-				$numValues = 0;
-				while ( ( $object = $field->getNextDataValue() ) !== false ) {
-					$numValues++;
-					if($numValues > 1){
-						$this->setOrAppendStringDataValue( $object, $sheet, $colOffset, $rowOffset );
-					}else{
-						//NOTE: must check against subclasses before superclasses
-						if ( $object instanceof \SMWQuantityValue ) {
-							$this->setQuantityDataValue( $object, $sheet, $colOffset, $rowOffset );
-						} else if ( $object instanceof \SMWNumberValue ) {
-							$this->setNumberDataValue( $object, $sheet, $colOffset, $rowOffset );
-						} else {
-							$this->setOrAppendStringDataValue( $object, $sheet, $colOffset, $rowOffset );
-						}
-					}
-				}
-				$colOffset++;
-			}
+			$this->rowNum++;
+			$this->colNum = 0;
+			$this->readRowData($row);
 		}
 	}
 
@@ -133,18 +133,15 @@ class SRFExcel extends SMWExportPrinter {
 	 * convert the cell to a string and append the data value. Creating
 	 * a list of comma separated entries.
 	 *
-	 * @param $object    the raw data value object
-	 * @param $sheet     the current phpexcel sheet
-	 * @param $colOffset the col offset to store the data
-	 * @param $rowOffset the row offset to store the data
+	 * @param $object \SMWDataValue the raw data value object
 	 */
-	protected function setOrAppendStringDataValue ( $object, \PHPExcel_Worksheet $sheet, $colOffset, $rowOffset ) {
+	protected function setOrAppendStringDataValue ( $object ) {
 		$type = PHPExcel_Cell_DataType::TYPE_STRING;
 		$value = $object->getWikiValue();
 		$value = Sanitizer::decodeCharReferences( $value );
 		$value = PHPExcel_Cell_DataType::checkString( $value );
 
-		$cell = $sheet->getCellByColumnAndRow( $colOffset, $rowOffset );
+		$cell = $this->sheet->getCellByColumnAndRow( $this->colNum, $this->rowNum );
 		$existingValue = $cell->getValue();
 		if($existingValue){
 			$value = $cell->getValue().','.$value;
@@ -155,35 +152,29 @@ class SRFExcel extends SMWExportPrinter {
 	/**
 	 * Sets a numeric value at the given col,row location
 	 *
-	 * @param $object    the raw data value object
-	 * @param $sheet     the current phpexcel sheet
-	 * @param $colOffset the col offset to store the data
-	 * @param $rowOffset the row offset to store the data
+	 * @param $object \SMWDataValue the raw data value object
 	 */
-	protected function setNumberDataValue ( $object, $sheet, $colOffset, $rowOffset ) {
+	protected function setNumberDataValue ( $object ) {
 		$type = PHPExcel_Cell_DataType::TYPE_NUMERIC;
 		$value = $object->getDataItem()->getNumber();
 
-		$sheet->getCellByColumnAndRow( $colOffset, $rowOffset )
+		$this->sheet->getCellByColumnAndRow( $this->colNum, $this->rowNum )
 			->setValueExplicit( $value, $type );
 	}
 
 	/**
 	 * Sets a quantity value at the given col,row location
 	 *
-	 * @param $object    the raw data value object
-	 * @param $sheet     the current phpexcel sheet
-	 * @param $colOffset the col offset to store the data
-	 * @param $rowOffset the row offset to store the data
+	 * @param $object \SMWDataValue  the raw data value object
 	 */
-	protected function setQuantityDataValue ( $object, $sheet, $colOffset, $rowOffset ) {
+	protected function setQuantityDataValue ( $object ) {
 		$type = PHPExcel_Cell_DataType::TYPE_NUMERIC;
 		$unit = $object->getUnit();
 		$value = $object->getNumber();
 
-		$sheet->getCellByColumnAndRow( $colOffset, $rowOffset )
+		$this->sheet->getCellByColumnAndRow( $this->colNum, $this->rowNum )
 			->setValueExplicit( $value, $type );
-		$sheet->getStyleByColumnAndRow( $colOffset, $rowOffset )
+		$this->sheet->getStyleByColumnAndRow( $this->colNum, $this->rowNum )
 			->getNumberFormat()
 			->setFormatCode( '0 "' . $unit . '"' );
 	}
@@ -192,21 +183,18 @@ class SRFExcel extends SMWExportPrinter {
 	 * Populates the PHPExcel sheet with the headers from the result query
 	 *
 	 * @param $res   the query result
-	 * @param $sheet the current phpexcel sheet
 	 */
-	protected function populateDocumentWithHeaders ( $res, $sheet ) {
-		$colOffset = 0;
+	protected function populateDocumentWithHeaders ( $res ) {
+		$this->colNum = 0;
 		foreach ( $res->getPrintRequests() as $pr ) {
 			$header = $pr->getLabel();
-			if($this->skipExtraMainLabel($header) ){
-				//Skip extra header ending with # caused by mainlabel parameter
-				continue;
+			if($this->showLabel($header) ){
+				$this->sheet->setCellValueByColumnAndRow( $this->colNum, self::HEADER_ROW_OFFSET, $header )
+					->getStyleByColumnAndRow( $this->colNum, self::HEADER_ROW_OFFSET )
+					->getFont()
+					->setBold( true );
+				$this->colNum++;
 			}
-			$sheet->setCellValueByColumnAndRow( $colOffset, self::HEADER_ROW_OFFSET, $header )
-				->getStyleByColumnAndRow( $colOffset, self::HEADER_ROW_OFFSET )
-				->getFont()
-				->setBold( true );
-			$colOffset++;
 		}
 	}
 
@@ -224,24 +212,60 @@ class SRFExcel extends SMWExportPrinter {
 		return $objPHPExcel;
 	}
 
-	public function getParamDefinitions ( array $definitions ) {
-		$params = parent::getParamDefinitions( $definitions );
-
-		$definitions[ 'searchlabel' ]->setDefault( wfMessage( 'srf-excel-link' )->inContentLanguage()->text() );
-
-		return $params;
-	}
-
 	private function isPHPExcelInstalled () {
 		return class_exists( "PHPExcel" );
 	}
 
 	/**
+	 * Check for the existence of the extra mainlabel.
 	 * @param $label
 	 * @return bool
 	 */
-	private function skipExtraMainLabel( $label ) {
-		return array_key_exists("mainlabel", $this->params) && $label === $this->params[ "mainlabel" ] . '#';
+	private function showLabel( $label ) {
+		return !(array_key_exists("mainlabel", $this->params) && $label === $this->params[ "mainlabel" ] . '#');
+	}
+
+	/**
+	 * @param $field
+	 */
+	protected function readFieldValue( $field ) {
+		$valueCount = 0;
+		while ( ( $object = $field->getNextDataValue() ) !== false ) {
+			if( $valueCount === 0 ) {
+				$this->setValueAccordingToType($object);
+			} else {
+				$this->setOrAppendStringDataValue($object);
+			}
+			$valueCount++;
+		}
+	}
+
+	/**
+	 * Checks the type of the value, and set's it in the sheet accordingly
+	 * @param $object
+	 */
+	protected function setValueAccordingToType( $object ) {
+		//NOTE: must check against subclasses before superclasses
+		if( $object instanceof \SMWQuantityValue ) {
+			$this->setQuantityDataValue($object);
+		} else if( $object instanceof \SMWNumberValue ) {
+			$this->setNumberDataValue($object);
+		} else {
+			$this->setOrAppendStringDataValue($object);
+		}
+	}
+
+	/**
+	 * Traverses row data
+	 * @param $row
+	 */
+	protected function readRowData( $row ) {
+		foreach ( $row as $field ) {
+			if( $this->showLabel($field->getPrintRequest()->getLabel()) ) {
+				$this->readFieldValue($field);
+				$this->colNum++;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
if mainlabel parameter was set to "Test", the first two columns in the excel
file would result in column headers like the following:

Test    Test#

This patch filters out the second column header Test#

Note, this is also the result seen in the CSV format...
