### PR TITLE
Made excel export format enabled by default 

### DIFF
--- a/SemanticResultFormats.settings.php
+++ b/SemanticResultFormats.settings.php
@@ -71,9 +71,6 @@ $GLOBALS['srfgFormats'] = array(
 	// 'googlebar',
 	// 'googlepie',
 
-	//Disabled by default since it requires PHPExcel extension
-	// 'excel',
-
 	// Unstable/broken:
 	// 'exhibit',
 );
@@ -85,6 +82,11 @@ if(	array_key_exists( 'ExtHashTables', $GLOBALS['wgAutoloadClasses'] ) && define
 	|| isset( $GLOBALS['wgHashTables'] ) // Version < 1.0 alpha
 ) {
 	$GLOBALS['srfgFormats'][] = 'hash';
+}
+
+//load excel format only if PHPExcel is installed.
+if(\SRF\SRFExcel::isPHPExcelInstalled()){
+	$GLOBALS['srfgFormats'][] = 'excel';
 }
 
 // Used for Array and Hash formats.

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,9 @@
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": "1.9.*"
 	},
+	"suggest": {
+        	"phpoffice/phpexcel": "Used when exporting to excel format using 'format=excel'"
+	},
 	"autoload": {
 		"files" : [
 			"SemanticResultFormats.php"

--- a/formats/excel/SRF_Excel.php
+++ b/formats/excel/SRF_Excel.php
@@ -54,7 +54,7 @@ class SRFExcel extends SMWExportPrinter {
 	}
 
 	public function outputAsFile ( SMWQueryResult $queryResult, array $params ) {
-		if ( $this->isPHPExcelInstalled() ) {
+		if ( self::isPHPExcelInstalled() ) {
 			parent::outputAsFile( $queryResult, $params );
 		} else {
 			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -76,7 +76,7 @@ class SRFExcel extends SMWExportPrinter {
 	 */
 	protected function getResultText ( SMWQueryResult $res, $outputmode ) {
 		if ( $outputmode == SMW_OUTPUT_FILE ) {
-			if ( $this->isPHPExcelInstalled() ) {
+			if ( self::isPHPExcelInstalled() ) {
 				$document = $this->createExcelDocument();
 				$this->sheet = $document->getSheet( 0 );
 
@@ -212,10 +212,6 @@ class SRFExcel extends SMWExportPrinter {
 		return $objPHPExcel;
 	}
 
-	private function isPHPExcelInstalled () {
-		return class_exists( "PHPExcel" );
-	}
-
 	/**
 	 * Check for the existence of the extra mainlabel.
 	 * @param $label
@@ -266,6 +262,10 @@ class SRFExcel extends SMWExportPrinter {
 				$this->colNum++;
 			}
 		}
+	}
+
+	public static function isPHPExcelInstalled(){
+		return class_exists( "PHPExcel" );
 	}
 }
 


### PR DESCRIPTION
Made excel export format enabled by default
Added PHPExcel as a suggested library through composer

If PHPExcel is not installed, the excel export format will output an error 
message describing that PHPExcel is not installed and direct users to read on
documentation website on how to install it.

The error message however is only displayed when someone tries to use the excel format.

Also since composer.json now suggests the phpexcel library, it is given as an option to install when installing semantic result formats.
