### PR TITLE
Check for instanceof Title

### DIFF
--- a/formats/tagcloud/TagCloud.php
+++ b/formats/tagcloud/TagCloud.php
@@ -77,7 +77,7 @@ class TagCloud extends ResultPrinter {
 
 		// Template support
 		$this->hasTemplates = $this->params['template'] !== '';
-		$this->isHTML = $this->getTitle()->isSpecialPage() && !$this->hasTemplates;
+		$this->isHTML = ( $this->getTitle() instanceof Title && $this->getTitle()->isSpecialPage() ) && !$this->hasTemplates;
 
 		// Register RL module
 		if ( in_array( $this->params['widget'], array( 'sphere', 'wordcloud' ) ) ) {


### PR DESCRIPTION
Mail from Cicalese, Cindy:

Tested on MediaWiki 1.21 and 1.22 throws PHP Fatal error:  Call to a member function isSpecialPage() on a non-object in …/mediawiki/extensions/SemanticResultFormats/formats/tagcloud/TagCloud.php on line 80

 I get this error if I include any tagcloud in my wiki. An example is the following:

```
{{#ask:[[Tags::+]]
|?Tags
|format=tagcloud
|template=TagTagCloud
|maxtags=75
|limit=10000
}}
```
