### PR TITLE
Update SRF_Filtered.php

### DIFF
--- a/formats/Filtered/SRF_Filtered.php
+++ b/formats/Filtered/SRF_Filtered.php
@@ -280,7 +280,7 @@ class SRFFiltered extends SMWResultPrinter {
 		$params[] = array(
 			// 'type' => 'string',
 			'name' => 'views',
-			'message' => 'srf-paramdesc-views',
+			'message' => 'srf-paramdesc-filtered-views',
 			'default' => '',
 			// 'islist' => false,
 		);


### PR DESCRIPTION
Amend name of the message key to correspond to the I18n file and thus regain consistency (see issue https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/71)
