### PR TITLE
[Calendar] added startmonth and startyear parameter

### DIFF
--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -14,6 +14,8 @@ class SRFCalendar extends SMWResultPrinter {
 	protected $mTemplate;
 	protected $mUserParam;
 	protected $mRealUserLang = null;
+	protected $mStartMonth;
+	protected $mStartYear;
 
 	protected function setColors( $colorsText ) {
 		$colors = array();
@@ -32,6 +34,8 @@ class SRFCalendar extends SMWResultPrinter {
 
 		$this->mTemplate = trim( $params['template'] );
 		$this->mUserParam = trim( $params['userparam'] );
+		$this->mStartMonth = trim( $params['startmonth'] );	// startmonth is initialized with current month by default
+		$this->mStartYear = trim( $params['startyear'] );	// startyear is initialized with current year by default
 
 		if ( $params['lang'] !== false ) {
 			global $wgLang;
@@ -348,7 +352,13 @@ class SRFCalendar extends SMWResultPrinter {
 		// and years (same - note that the previous or next month could
 		// be in a different year), the number of days in the current,
 		// previous and next months, etc.
-		$cur_month_num = date( 'n', time() );
+
+
+		if ( is_numeric( $this->mStartMonth ) && ( intval( $this->mStartMonth ) == $this->mStartMonth ) && $this->mStartMonth >= 1 && $this->mStartMonth <= 12 ) {
+			$cur_month_num = $this->mStartMonth;
+		} else {
+			$cur_month_num = date( 'n' );
+		}
 		if ( $wgRequest->getCheck( 'month' ) ) {
 			$query_month = $wgRequest->getVal( 'month' );
 			if ( is_numeric( $query_month ) && ( intval( $query_month ) == $query_month ) && $query_month >= 1 && $query_month <= 12 ) {
@@ -357,7 +367,12 @@ class SRFCalendar extends SMWResultPrinter {
 		}
 
 		$cur_month = self::intToMonth( $cur_month_num );
-		$cur_year = date( 'Y', time() );
+
+		if ( is_numeric( $this->mStartYear ) && ( intval( $this->mStartYear ) == $this->mStartYear ) ) {
+			$cur_year = $this->mStartYear;
+		} else {
+			$cur_year = date( 'Y' );
+		}
 		if ( $wgRequest->getCheck( 'year' ) ) {
 			$query_year = $wgRequest->getVal( 'year' );
 			if ( is_numeric( $query_year ) && intval( $query_year ) == $query_year ) {
@@ -568,6 +583,16 @@ END;
 			'default' => '',
 		);
 
+		$params['startmonth'] = array(
+			'message' => 'srf-paramdesc-calendar-startmonth',
+			'default' => date( 'n' ),
+		);
+		
+		$params['startyear'] = array(
+			'message' => 'srf-paramdesc-calendar-startyear',
+			'default' => date( 'Y' ),
+		);
+		
 		return $params;
 	}
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -58,6 +58,8 @@
 	"srf_printername_calendar": "Zeit (Kalender)",
 	"srf_paramdesc_calendarlang": "Der Sprachcode der Sprache, in der der Kalender angezeigt werden soll",
 	"srf_paramdesc_calendarcolors": "Die für das jeweilige Datumsattribut zur Darstellung zu verwendende Farbe (Beispiel: „Startdatum=>green,Enddatum=>#09C“)",
+	"srf-paramdesc-calendar-startmonth": "Der Monat, mit dem die Kalenderanzeige initialisiert wird (Standard ist der aktuelle Monat)",
+	"srf-paramdesc-calendar-startyear": "Das Jahr, mit dem die Kalenderanzeige initialisiert wird (Standard ist das aktuelle Jahr)",
 	"srf_printername_vcard": "Export (vCard)",
 	"srf_printername_icalendar": "Export (iCalendar)",
 	"srf_paramdesc_icalendartitle": "Der Name für die Kalenderdatei",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -48,6 +48,8 @@
     "srf_printername_calendar": "Monthly calendar",
     "srf_paramdesc_calendarlang": "The code for the language in which to display the calendar",
     "srf_paramdesc_calendarcolors": "The color to display for each date property (example: \"Start date=>green,End date=>#09c\")",
+    "srf-paramdesc-calendar-startmonth": "The month, the calendar display is initialized with (defaults to current month)",
+    "srf-paramdesc-calendar-startyear": "The year, the calendar display is initialized with (defaults to current year)",
     "srf_vcard_link": "vCard",
     "srf_printername_vcard": "vCard export",
     "srf_icalendar_link": "iCalendar",


### PR DESCRIPTION
I needed SRF Calendar to show a specific month/year instead of the current one. So I implemented two new parameter: startmonth and startyear. Both defaults to current values if not specified.