### PR TITLE
Fix for running composer locally

### DIFF
--- a/SemanticResultFormats.php
+++ b/SemanticResultFormats.php
@@ -23,7 +23,7 @@ if ( version_compare( $GLOBALS['wgVersion'], '1.19c', '<' ) ) {
 	throw new Exception( 'This version of Semantic Result Formats requires MediaWiki 1.19 or above; use SRF 1.7.x or SRF 1.6.x for older versions.' );
 }
 
-if ( !defined( 'SMW_VERSION' ) && is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
+if ( is_readable( __DIR__ . '/vendor/autoload.php' ) ) {
 	include_once( __DIR__ . '/vendor/autoload.php' );
 }
 


### PR DESCRIPTION
If another composer-installed extension (e.g. Semantic Extra Special Properties) installs Semantic MediaWiki in its local extension vendor directory, Semantic MediaWiki will be autoloaded from there, but the files for this extension will never be autoloaded (because SMW_VERSION will already be defined). Perhaps there is a better solution, but with this change, if composer is run in the SemanticResultFormats directory to create its local vendor directory, the code will now be sure to autoload the files for this extension.