### PR TITLE
Added displaytitle parameter, for rudimentary DISPLAYTITLE / Semantic Title Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "fannon/semantic-result-formats",
+	"name": "mediawiki/semantic-result-formats",
 	"type": "mediawiki-extension",
 	"description": "Additional result formats for Semantic MediaWiki queries",
 	"keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mediawiki/semantic-result-formats",
+	"name": "fannon/semantic-result-formats",
 	"type": "mediawiki-extension",
 	"description": "Additional result formats for Semantic MediaWiki queries",
 	"keywords": [

--- a/formats/Filtered/SRF_Filtered.php
+++ b/formats/Filtered/SRF_Filtered.php
@@ -248,6 +248,7 @@ class SRFFiltered extends SMWResultPrinter {
 				', "filterdata" : ' . json_encode( $filterData ) .
 				', "sorthandlers" : ' . json_encode( array() ) .
 				', "sorterdata" : ' . json_encode( array() ) .
+				', "displaytitle" : ' . json_encode( $this->mParams['displaytitle'] ) .
 //				', "sorterhandlers" : ' . json_encode( $sorterHandlers ) .
 //				', "sorterdata" : ' . json_encode( $sorterData ) .
 				'}};'
@@ -292,6 +293,14 @@ class SRFFiltered extends SMWResultPrinter {
 			'name' => 'filter position',
 			'message' => 'srf-paramdesc-filtered-filter-position',
 			'default' => 'top',
+			// 'islist' => false,
+		);
+
+		$params[] = array(
+			'type' => 'boolean',
+			'name' => 'displaytitle',
+			'message' => 'srf-paramdesc-filtered-displaytitle',
+			'default' => false,
 			// 'islist' => false,
 		);
 

--- a/formats/Filtered/libs/ext.srf.filtered.js
+++ b/formats/Filtered/libs/ext.srf.filtered.js
@@ -29,6 +29,14 @@
 					var title = $(this).attr('title');
 					if (title) {
 						data['data']['displaytitle-map'][title] = $(this).text();
+
+						// Handle namespaces containing spaces/underscores
+						if (title.indexOf(':') > -1) {
+							titleArray = title.split(':');
+							titleArray[0] = titleArray[0].split(' ').join('_');
+							title = titleArray.join(':');
+							data['data']['displaytitle-map'][title] = $(this).text();
+						}
 					}
 				});
 			}

--- a/formats/Filtered/libs/ext.srf.filtered.js
+++ b/formats/Filtered/libs/ext.srf.filtered.js
@@ -14,8 +14,27 @@
 
 		init: function( args ){
 
+			var data = args['data'];
+
+			// If the displaytitle param is set to true, create a displaytitle map
+			// This allows to lookup the label for a page title
+			// E.g. Issue 0001: Title of the Issue
+			// TODO: Replace this, once this is included: https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1227
+			if (data['data']['displaytitle']) {
+				data['data']['displaytitle-map'] = {};
+
+				data['data']['displaytitle-map'][mw.config.get('wgPageName')] = $('h1.firstHeading').text();
+
+				$('.filtered-views a').each(function() {
+					var title = $(this).attr('title');
+					if (title) {
+						data['data']['displaytitle-map'][title] = $(this).text();
+					}
+				});
+			}
+
 			return this.each( function() {
-				var data = args['data'];
+
 				$(this).data( 'ext.srf.filtered', data );
 
 				// take note of filters, views and sorters we expect to be loaded

--- a/formats/Filtered/libs/ext.srf.filtered.value-filter.js
+++ b/formats/Filtered/libs/ext.srf.filtered.value-filter.js
@@ -19,9 +19,6 @@
 				var values = filtered.data('ext.srf.filtered')['values'];
 				var selectedInputs = filtercontrols.children('div.filtered-value-option').children('input:checked');
 
-				console.info('value-filter.init()');
-
-
 				// show all if no value is checked
 				if ( selectedInputs.length == 0 ) {
 					for ( valueId in values ) {

--- a/formats/Filtered/libs/ext.srf.filtered.value-filter.js
+++ b/formats/Filtered/libs/ext.srf.filtered.value-filter.js
@@ -19,6 +19,9 @@
 				var values = filtered.data('ext.srf.filtered')['values'];
 				var selectedInputs = filtercontrols.children('div.filtered-value-option').children('input:checked');
 
+				console.info('value-filter.init()');
+
+
 				// show all if no value is checked
 				if ( selectedInputs.length == 0 ) {
 					for ( valueId in values ) {
@@ -268,9 +271,17 @@
 					}, 0);
 				});
 
+				var label = sortedDistinctValues[j];
+
+				// If displaytitle is enabled, use the displaytitleMap and make a lookup for the label
+				var displaytitleMap = filtered.data('ext.srf.filtered')['data']['displaytitle-map'];
+				if (displaytitleMap && displaytitleMap[label]) {
+					label = displaytitleMap[label];
+				}
+
 				option
 				.append(checkbox)
-				.append(sortedDistinctValues[j]);
+				.append(label);
 
 				filtercontrols
 				.append(option);

--- a/formats/Filtered/libs/ext.srf.filtered.value-filter.js
+++ b/formats/Filtered/libs/ext.srf.filtered.value-filter.js
@@ -272,8 +272,11 @@
 
 				// If displaytitle is enabled, use the displaytitleMap and make a lookup for the label
 				var displaytitleMap = filtered.data('ext.srf.filtered')['data']['displaytitle-map'];
-				if (displaytitleMap && displaytitleMap[label]) {
-					label = displaytitleMap[label];
+				var txt = document.createElement("textarea");
+			    txt.innerHTML = label;
+			    decodedLabel =  txt.value;
+				if (displaytitleMap && displaytitleMap[decodedLabel]) {
+					label = displaytitleMap[decodedLabel];
 				}
 
 				option

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -120,6 +120,7 @@
 	"srf-paramdesc-gridview": "Display chart and data sets simultaneously. Allowed values: \"none\" and \"tabs\". Default: \"none\"",
 	"srf-paramdesc-paneview": "Specify the position of the pane containing a small line chart. Allowed values: \"bottom\", \"top\" and \"none\". Default: \"bottom\"",
 	"srf-paramdesc-infotext": "Display additional information on a corresponding info tab",
+	"srf-paramdesc-filtered-displaytitle": "Use DISPLAYTITLE / SemanticTitle as label",
 	"srf-ui-gridview-label-item": "Data item",
 	"srf-ui-gridview-label-value": "Data value",
 	"srf-ui-gridview-label-series": "Data series",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -232,6 +232,7 @@
 	"srf-paramdesc-effect": "{{doc-paramdesc|effect}}",
 	"srf-printername-filtered": "{{doc-smwformat|filtered}}",
 	"srf-paramdesc-filtered-views": "{{doc-paramdesc|views}}\n\nA view is how the queried information is shown to the user, e.g. as a table or a calendar, etc.",
+	"srf-paramdesc-filtered-displaytitle": "{{doc-paramdesc|srf_paramdesc_displaytitle}}\n\nCorresponds to the {{DISPLAYTITLE:title}} magic word",
 	"srf-paramdesc-filtered-filter-position": "{{doc-paramdesc|filter position}}\n{{doc-important|Do not translate the parameter values \"top\" and \"bottom\".}}",
 	"srf-paramdesc-filtered-list-type": "{{doc-paramdesc|list view type}}\n{{doc-important|Do not translate the parameter values \"list\", \"ul\" and \"ol\"}}",
 	"srf-paramdesc-filtered-list-template": "{{doc-paramdesc|list view template}}",


### PR DESCRIPTION
This patch will add support for SemanticTitle for the filtered format. It is far from optimal, but as the displaytitle is currently not available in the QueryResult object this is what I came up with.

When activated with displaytitle=true (by default the patch will do nothing), a map of title -> displaytitle will be built and used to assign the Filter Checkboxes the correct label.