### PR TITLE
Filtered format: Fix Uncaught TypeError: fixedValues.split is not a function

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,8 @@ These are the release notes for the [Semantic Result Formats]
 * Fixed bug causing occasional exceptions in the calendar format (by Mark A. Hershberger)
 * Fixed bug in timeseries format that caused the value 0 to be excluded (by MWJames)
 * Fixed bug in the calendar parser functions (by James Montalvo)
+* Fixed bug in filtered format that broke the format on browsers supporting the
+  [Array.prototype.values()](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/values) method
 
 ## SRF 2.3 (2015-09-24)
 

--- a/formats/Filtered/libs/ext.srf.filtered.js
+++ b/formats/Filtered/libs/ext.srf.filtered.js
@@ -282,7 +282,8 @@
 			} else if ( params['configvar'] == undefined ) {
 				return this.data('ext.srf.filtered')['data']['filterdata'][params['filter']][params['printout']];
 			} else {
-				if (this.data('ext.srf.filtered')['data']['filterdata'][params['filter']][params['printout']] != null) {
+				if ( this.data('ext.srf.filtered')['data']['filterdata'][params['filter']][params['printout']] != null &&
+					typeof this.data('ext.srf.filtered')['data']['filterdata'][params['filter']][params['printout']][params['configvar']] == 'string' ) {
 					return this.data('ext.srf.filtered')['data']['filterdata'][params['filter']][params['printout']][params['configvar']];
 				} else {
 					return null;


### PR DESCRIPTION
Chrome 51+ and Firefox 48+ support the Array.prototype.values() method, which clashes with the 'values' parameter of the value filter. So we have to make sure, that when accessing that field we really get a string (i.e. something we set ourselves) and not a function (provided in the Array prototype).

See https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/values