### PR TITLE
Add displaytitle label support to filtered format, fix sorting order

### DIFF
--- a/formats/Filtered/libs/ext.srf.filtered.value-filter.js
+++ b/formats/Filtered/libs/ext.srf.filtered.value-filter.js
@@ -123,18 +123,31 @@
 			} );
 
 			var valueId; // just some valid value ID
+
+			/** Map of value => label distinct values */
+			var distinctValues = {};
+
+			/** Sorted array of distinct values */
+			var sortedDistinctValues = [];
+
 			if ( fixedValues == null ) {
 				// build filter values from available values in result set
 
 				// find distinct values and set visibility for all items that have
 				// some value for this printout
-				var distinctValues = [];
 
 				for ( valueId in values ) {
+
 					var printoutValues = values[valueId]['printouts'][target]['values'];
 
 					for (var j in printoutValues) {
-						distinctValues[ printoutValues[j] ] = true;
+						var formattedValue = values[valueId]['printouts'][target]['formatted values'][j];
+						var label = printoutValues[j] ;
+						// If the formatted Value is a link, it may contain a label (DISPLAYTITLE)
+						if (formattedValue.indexOf('<a') > -1) {
+							label = /<a.*>(.*?)<\/a>/.exec(formattedValue)[1];
+						}
+						distinctValues[ printoutValues[j] ] = label;
 					}
 
 					filtered.filtered( 'voteItemVisibility', {
@@ -145,13 +158,8 @@
 					});
 				}
 
-				var sortedDistinctValues = [];
+				sortedDistinctValues = Object.keys(distinctValues).sort()
 
-				for ( var i in distinctValues ) {
-					sortedDistinctValues.push(i);
-				}
-
-				sortedDistinctValues.sort();
 			} else {
 				// use given values
 				sortedDistinctValues = fixedValues.split(/\s*,\s*/);
@@ -254,11 +262,14 @@
 				filtercontrols.height( height );
 			}
 
-
 			// insert options (checkboxes and labels) and attach event handlers
 			// TODO: Do we need to wrap these in a form?
-			for ( var j in sortedDistinctValues ) {
+			for (var j = 0; j < sortedDistinctValues.length; j++) {
 				var option = $('<div class="filtered-value-option">');
+
+				// Try to get label, if not fall back to value id
+				var label = distinctValues[sortedDistinctValues[j]] || sortedDistinctValues[j];
+
 				var checkbox = $('<input type="checkbox" class="filtered-value-value" value="' + sortedDistinctValues[j] + '"  >');
 
 				// attach event handler
@@ -268,12 +279,9 @@
 					}, 0);
 				});
 
-				option
-				.append(checkbox)
-				.append(sortedDistinctValues[j]);
+				option.append(checkbox).append(label);
 
-				filtercontrols
-				.append(option);
+				filtercontrols.append(option);
 
 			}
 


### PR DESCRIPTION
This pull request is a proper version of the  #144 pull request.

It introduces support for displaytitle labels for the filters itself in the filtered format, given that at least SMW >= 2.4 is used. If SMW is of a lower version, this patch will fall back to use the ID as the label.

When testing, I found one catch: When `link=none` is used, no label can be detected, as it is extracted for the `formatted value` `<a>` tag. In that case there is no way for the result format to know what the label should have been.

This pull request also fixes a potential issue with the alphabetical ordering of the filters. Previously an object (dictionary) was used. Those do not guarantuee the order of their keys. Most browsers keep the order until a certain size, but after that they will shuffle it up.

Best,
Simon

