### PR TITLE
Add integration testing using JSONScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - env: DB=mysql; MW=REL1_27; PHPUNIT=4.8.*
       php: 5.6
-    - env: DB=sqlite; MW=1.23.17
+    - env: DB=sqlite; MW=REL1_25
       php: 5.5
     - env: DB=sqlite; MW=1.28.2
       php: 7.0

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,3 +12,5 @@ print sprintf( "\n%-20s%s\n", "Semantic Result Formats: ", SRF_VERSION );
 
 $autoloader = require $path;
 $autoloader->addPsr4( 'SRF\\Tests\\', __DIR__ . '/phpunit' );
+$autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );
+$autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SRF\Tests\Integration\JSONScript;
+
+use SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest as SMWJsonTestCaseScriptRunnerTest;
+
+/**
+ * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests#write-integration-tests-using-json-script
+ *
+ * `JsonTestCaseScriptRunner` provisioned by SMW is a base class allowing to use a JSON
+ * format to create test definitions with the objective to compose "real" content
+ * and test integration with MediaWiki, Semantic MediaWiki, and Scribunto.
+ *
+ * The focus is on describing test definitions with its content and specify assertions
+ * to control the expected base line.
+ *
+ * `JsonTestCaseScriptRunner` will handle the tearDown process and ensures that no test
+ * data are leaked into a production system but requires an active DB connection.
+ *
+ * @group SRF
+ * @group SMWExtension
+ *
+ * @license GNU GPL v2+
+ * @since 2.5
+ *
+ * @author mwjames
+ */
+class JsonTestCaseScriptRunnerTest extends SMWJsonTestCaseScriptRunnerTest {
+
+	/**
+	 * @see \SMW\Tests\JsonTestCaseScriptRunner::getTestCaseLocation
+	 * @return string
+	 */
+	protected function getTestCaseLocation() {
+		return __DIR__ . '/TestCases';
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -1,0 +1,18 @@
+## TestCases
+
+<!-- Begin of generated contents by readmeContentsBuilder.php -->
+
+## TestCases
+
+Contains 1 files with a total of 1 tests:
+
+### B
+* [bootstrap.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/bootstrap.json) Example bootstrap test case (see https://youtu.be/7fDKjPFaTaY)
+
+-- Last updated on 2017-05-28 by `readmeContentsBuilder.php`
+
+<!-- End of generated contents by readmeContentsBuilder.php -->
+
+## Writing a test case
+
+See [the Semantic MediaWiki README on that topic](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript#designing-an-integration-test)

--- a/tests/phpunit/Integration/JSONScript/TestCases/bootstrap.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/bootstrap.json
@@ -1,0 +1,53 @@
+{
+	"description": "Example bootstrap test case (see https://youtu.be/7fDKjPFaTaY)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has example",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/Boostrap",
+			"contents": "[[Has example::Example123]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (page type annotation)",
+			"subject": "Example/Boostrap",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_SKEY",
+						"_MDAT",
+						"Has example"
+					],
+					"propertyValues": [
+						"Example123"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Example123"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #220

This PR adds minimum JSONScript integration test support to Semantic Result Formats.

This PR includes:
- [x] Tests (unit/integration): Exisitng tests and newly added JSONScript bootstrap test case pass locally.
- [x] CI build passed
