### PR TITLE
Start 3.0.0 development version

### DIFF
--- a/SemanticResultFormats.php
+++ b/SemanticResultFormats.php
@@ -51,7 +51,7 @@ class SemanticResultFormats {
 	 */
 	public static function initExtension() {
 
-		define( 'SRF_VERSION', '2.5.0' );
+		define( 'SRF_VERSION', '3.0.0-alpha' );
 
 		// Register the extension
 		$GLOBALS['wgExtensionCredits']['semantic'][] = [

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.5.x-dev"
+			"dev-master": "3.0.x-dev"
 		}
 	},
 	"config": {


### PR DESCRIPTION
This PR is made in reference to: #190 

This PR addresses or contains:
- Starts the development of SRF 3.0.0 on master since 2.5.x is now on its own branch

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
