### PR TITLE
Fix #234: Use <ol> when format=oltree

### DIFF
--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -342,7 +342,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 */
 	protected function buildLinesFromTree( $tree ) {
 		$nodePrinterConfiguration = [
-			'format' => trim( $this->params[ 'template' ] ),
+			'format' => trim( $this->params[ 'format' ] ),
 			'template' => trim( $this->params[ 'template' ] ),
 			'headers' => $this->params[ 'headers' ],
 			'template arguments' => $this->params[ 'template arguments' ],

--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-01.json
@@ -70,6 +70,22 @@
 		{
 			"page": "Example/Tree 01-02",
 			"contents": "{{#ask:[[Part of::Tree test]]|format=tree|parent=Has parent|root=Example/Tree 1}}"
+		},
+		{
+			"page": "Example/Tree 01-03",
+			"contents": "{{#ask:[[Part of::Tree test]]|format=ultree|parent=Has parent}}"
+		},
+		{
+			"page": "Example/Tree 01-04",
+			"contents": "{{#ask:[[Part of::Tree test]]|format=ultree|parent=Has parent|root=Example/Tree 1}}"
+		},
+		{
+			"page": "Example/Tree 01-05",
+			"contents": "{{#ask:[[Part of::Tree test]]|format=oltree|parent=Has parent}}"
+		},
+		{
+			"page": "Example/Tree 01-06",
+			"contents": "{{#ask:[[Part of::Tree test]]|format=oltree|parent=Has parent|root=Example/Tree 1}}"
 		}
 	],
 	"tests": [
@@ -90,6 +106,54 @@
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li></ul>\n</div>"
+				],
+				"not-contain": [
+					"Example/Tree 2",
+					"Example/Tree 3"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 01-03 (Multi-page result (ultree))",
+			"subject": "Example/Tree 01-03",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ul><li><a href=\"/.*/Example/Tree_21\" title=\"Example/Tree 21\">Example/Tree 21</a></li>\n<li><a href=\"/.*/Example/Tree_22\" title=\"Example/Tree 22\">Example/Tree 22</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>\n<ul><li><a href=\"/.*/Example/Tree_31\" title=\"Example/Tree 31\">Example/Tree 31</a></li>\n<li><a href=\"/.*/Example/Tree_32\" title=\"Example/Tree 32\">Example/Tree 32</a>\n<ul><li><a href=\"/.*/Example/Tree_321\" title=\"Example/Tree 321\">Example/Tree 321</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_33\" title=\"Example/Tree 33\">Example/Tree 33</a></li></ul></li></ul>\n</div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 01-04 (Multi-page result with root specified (ultree))",
+			"subject": "Example/Tree 01-04",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li></ul>\n</div>"
+				],
+				"not-contain": [
+					"Example/Tree 2",
+					"Example/Tree 3"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 01-05 (Multi-page result (oltree))",
+			"subject": "Example/Tree 01-05",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-tree\">\n<ol><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ol><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ol><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ol><li><a href=\"/.*/Example/Tree_21\" title=\"Example/Tree 21\">Example/Tree 21</a></li>\n<li><a href=\"/.*/Example/Tree_22\" title=\"Example/Tree 22\">Example/Tree 22</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>\n<ol><li><a href=\"/.*/Example/Tree_31\" title=\"Example/Tree 31\">Example/Tree 31</a></li>\n<li><a href=\"/.*/Example/Tree_32\" title=\"Example/Tree 32\">Example/Tree 32</a>\n<ol><li><a href=\"/.*/Example/Tree_321\" title=\"Example/Tree 321\">Example/Tree 321</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_33\" title=\"Example/Tree 33\">Example/Tree 33</a></li></ol></li></ol>\n</div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 01-06 (Multi-page result with root specified (oltree))",
+			"subject": "Example/Tree 01-06",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-tree\">\n<ol><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ol><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ol><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ol></li></ol>\n</div>"
 				],
 				"not-contain": [
 					"Example/Tree 2",


### PR DESCRIPTION
This PR is made in reference to: #234 

This PR addresses or contains:
- Make `tree-01.json` fail when #234 present
- Actually use `<ol>` when `format=oltree`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
