### PR TITLE
Update dependencies for upcoming SRF 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,20 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_27; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=master; SMW=~3.0@dev
       php: 5.6
-    - env: DB=sqlite; MW=REL1_25
-      php: 5.5
-    - env: DB=sqlite; MW=1.28.2
+    - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev
       php: 7.0
+    - env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
+      php: 7.0
+    - env: DB=mysql; MW=1.27.3; SMW=~3.0@dev
+      php: 5.6
+    - env: DB=postgres; MW=1.27.3; SMW=~3.0@dev
+      php: 5.6
+  allow_failures:
+    # Test previous versions to get an indication of actual loss of compatibility
+    - env: DB=mysql; MW=1.23.17; SMW=2.5.0; PHPUNIT=4.8.*
+      php: 5.6
 
 install:
   - bash ./build/travis/install-mediawiki.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,8 +18,8 @@ These are the installation and configuration instructions for [Semantic Result F
 		<td><a href="https://github.com/SemanticMediaWiki/SemanticResultFormats/tree/master">master</a></td>
 	</tr>
 	<tr>
-		<th><a href="https://github.com/SemanticMediaWiki/SemanticResultFormats/blob/master/docs/RELEASE-NOTES.md">SRF 2.5.0</a></th>
-		<td>Stabel version</td>
+		<th><a href="https://github.com/SemanticMediaWiki/SemanticResultFormats/blob/master/docs/RELEASE-NOTES.md">SRF 2.5.1</a></th>
+		<td>Stable version</td>
 		<td>2017-06-13</td>
 		<td><a href="https://github.com/SemanticMediaWiki/SemanticResultFormats/tree/2.5.x">2.5.x</a></td>
 	</tr>
@@ -90,13 +90,13 @@ minimum requirements are indicated in bold.
 		<th>SRF 3.0.x</th>
 		<td><strong>5.6.x</strong> - latest</td>
 		<td><strong>1.27</strong> - latest</td>
-		<td>2.x</td>
+		<td><strong>3.x</strong></td>
 	<tr>
 	<tr>
 		<th>SRF 2.5.x</th>
 		<td><strong>5.5.x</strong> - 7.0.x</td>
 		<td><strong>1.23</strong> - 1.29</td>
-		<td>2.x</td>
+		<td>2.x - latest</td>
 	<tr>
 		<th>SRF 2.4.x</th>
 		<td>5.3.2 - 7.0.x</td>
@@ -172,17 +172,11 @@ Composer now:
 
 Add the following line to the end of the "require" section in your "composer.local.json" file:
 ``` json
-    "mediawiki/semantic-result-formats": "~2.5"
+    "mediawiki/semantic-result-formats": "~3.0"
 ```
 
-   * Remark 1: Remember to add a comma to the end of the preceding line in this 
+   * Remark: Remember to add a comma to the end of the preceding line in this
      section.
-
-   * Remark 2: If you do not have a `composer.local.json` file (MediaWiki <1.25),
-     use `composer.json` instead.
-
-   * Remark 3: If you do not have a `composer.json` file (MediaWiki <1.24),
-     copy `composer.json.example` to `composer.json` first.
 
 #### Step 4
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ installation independently. For more information, visit the [SRF homepage][srf] 
 
 ## Requirements
 
-- PHP 5.5 or later
-- MediaWiki 1.23 or later (1.27 or later recommended)
-- Semantic MediaWiki 2.0 or later (2.5 or later recommended)
+- PHP 5.6 or later
+- MediaWiki 1.27 or later
+- Semantic MediaWiki 3.0 or later
 - MySQL 5 or later or SQLite 3 or later
 
 
@@ -29,7 +29,7 @@ Just add the following to the MediaWiki `composer.local.json` file and run the
 ```json
 {
 	"require": {
-		"mediawiki/semantic-result-formats": "~2.5"
+		"mediawiki/semantic-result-formats": "~3.0"
 	}
 }
 ```

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,8 @@ These are the release notes for the [Semantic Result Formats](https://www.semant
 
 This is not a release yet.
 
+* Raised minimum required version of PHP to 5.6
+* Raised minimum required version of MediaWiki to 1.27
 * Filtered: New parameter `map view height`
 * Provided translation updates (by translatewiki.net community)
 * #248 Fixed localized formatting of math results

--- a/build/travis/install-semantic-result-formats.sh
+++ b/build/travis/install-semantic-result-formats.sh
@@ -8,8 +8,13 @@ function installPHPUnitWithComposer {
 	if [ "$PHPUNIT" != "" ]
 	then
 		composer require 'phpunit/phpunit='$PHPUNIT --update-with-dependencies
-	else
-		composer require 'phpunit/phpunit=3.7.*' --update-with-dependencies
+	fi
+}
+
+function installSMWWithComposer {
+	if [ "$SMW" != "" ]
+	then
+		composer require 'mediawiki/semantic-media-wiki='$SMW --update-with-dependencies
 	fi
 }
 
@@ -20,6 +25,7 @@ function installToMediaWikiRoot {
 	cd $MW_INSTALL_PATH
 
 	installPHPUnitWithComposer
+	installSMWWithComposer
 	composer require mediawiki/semantic-result-formats "dev-master"
 
 	# Add optional packages

--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticResultFormats"
 	},
 	"require": {
-		"php": ">=5.5.0",
+		"php": ">=5.6.0",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/semantic-media-wiki": "~2.1|~3.0",
+		"mediawiki/semantic-media-wiki": "~3.0@dev",
 		"nicmart/tree": "^0.2.7",
 		"symfony/css-selector": "^3.3"
 	},


### PR DESCRIPTION
This PR is made in reference to: #259 

This PR updates dependencies for the upcoming SRF 3.0 and updates the test matrix accordingly.

This PR includes:
- [x] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [x] CI build passed
