### PR TITLE
Fix travis build matrix to actually run allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ matrix:
       php: 5.6
     - env: DB=postgres; MW=1.27.3; SMW=~3.0@dev
       php: 5.6
+    - env: DB=mysql; MW=1.23.17; SMW=~3.0@dev; PHPUNIT=4.8.*
+      php: 5.6
   allow_failures:
     # Test previous versions to get an indication of actual loss of compatibility
-    - env: DB=mysql; MW=1.23.17; SMW=2.5.0; PHPUNIT=4.8.*
+    - env: DB=mysql; MW=1.23.17; SMW=~3.0@dev; PHPUNIT=4.8.*
       php: 5.6
 
 install:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,7 +9,7 @@ This is not a release yet.
 * Filtered: New parameters `map view height`, `map view zoom`, `map view min zoom`, `map view max zoom`
 * Filtered: Improved testing
 * Provided translation updates (by translatewiki.net community)
-* #248 Fixed localized formatting of math results
+* (#248) Fixed localized formatting of math results
 
 ## SRF 2.5.1
 


### PR DESCRIPTION
The configuration allowed to fail needs to be listed among the configurations to be included in the tests as well.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [x] CI build ~~passed~~ failed for unrelated reasons
