### PR TITLE
Tree format: Use type `parser-html` for JsonScript tests

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-01.json
@@ -77,7 +77,7 @@
 		},
 		{
 			"page": "Example/Tree 01-04",
-			"contents": "{{#ask:[[Part of::Tree test]]|format=ultree|parent=Has parent|root=Example/Tree 1}}"
+			"contents": "{{#ask:[[Part of::Tree test]]|format=ultree|parent=Has parent|root=Example/Tree 3}}"
 		},
 		{
 			"page": "Example/Tree 01-05",
@@ -85,79 +85,123 @@
 		},
 		{
 			"page": "Example/Tree 01-06",
-			"contents": "{{#ask:[[Part of::Tree test]]|format=oltree|parent=Has parent|root=Example/Tree 1}}"
+			"contents": "{{#ask:[[Part of::Tree test]]|format=oltree|parent=Has parent|root=Example/Tree 2}}"
 		}
 	],
 	"tests": [
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-01 (Multi-page result)",
 			"subject": "Example/Tree 01-01",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ul><li><a href=\"/.*/Example/Tree_21\" title=\"Example/Tree 21\">Example/Tree 21</a></li>\n<li><a href=\"/.*/Example/Tree_22\" title=\"Example/Tree 22\">Example/Tree 22</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>\n<ul><li><a href=\"/.*/Example/Tree_31\" title=\"Example/Tree 31\">Example/Tree 31</a></li>\n<li><a href=\"/.*/Example/Tree_32\" title=\"Example/Tree 32\">Example/Tree 32</a>\n<ul><li><a href=\"/.*/Example/Tree_321\" title=\"Example/Tree 321\">Example/Tree 321</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_33\" title=\"Example/Tree 33\">Example/Tree 33</a></li></ul></li></ul>\n</div>"
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 21\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 22\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 31\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 32\"] + ul > li:only-child > a[title=\"Example/Tree 321\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 33\"]:only-child",
+
+					[ "div.srf-tree > ul:only-child", 1 ],
+					[ "div.srf-tree > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li", 8 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 2 ]
 				]
 			}
 		},
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-02 (Multi-page result with root specified)",
 			"subject": "Example/Tree 01-02",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li></ul>\n</div>"
-				],
-				"not-contain": [
-					"Example/Tree 2",
-					"Example/Tree 3"
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 1\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 1\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 1\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					[ "div.srf-tree > ul > li", 1 ],
+					[ "div.srf-tree > ul > li > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 1 ]
 				]
 			}
 		},
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-03 (Multi-page result (ultree))",
 			"subject": "Example/Tree 01-03",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ul><li><a href=\"/.*/Example/Tree_21\" title=\"Example/Tree 21\">Example/Tree 21</a></li>\n<li><a href=\"/.*/Example/Tree_22\" title=\"Example/Tree 22\">Example/Tree 22</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>\n<ul><li><a href=\"/.*/Example/Tree_31\" title=\"Example/Tree 31\">Example/Tree 31</a></li>\n<li><a href=\"/.*/Example/Tree_32\" title=\"Example/Tree 32\">Example/Tree 32</a>\n<ul><li><a href=\"/.*/Example/Tree_321\" title=\"Example/Tree 321\">Example/Tree 321</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_33\" title=\"Example/Tree 33\">Example/Tree 33</a></li></ul></li></ul>\n</div>"
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 21\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 22\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 31\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 32\"] + ul > li:only-child > a[title=\"Example/Tree 321\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 33\"]:only-child",
+
+					[ "div.srf-tree > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li", 8 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 2 ]
 				]
 			}
 		},
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-04 (Multi-page result with root specified (ultree))",
 			"subject": "Example/Tree 01-04",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li></ul>\n</div>"
-				],
-				"not-contain": [
-					"Example/Tree 2",
-					"Example/Tree 3"
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 3\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 31\"]:only-child",
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 3\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 32\"] + ul > li:only-child > a[title=\"Example/Tree 321\"]:only-child",
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 3\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 33\"]:only-child",
+
+					[ "div.srf-tree > ul > li", 1 ],
+					[ "div.srf-tree > ul > li > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 1 ]
 				]
 			}
 		},
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-05 (Multi-page result (oltree))",
 			"subject": "Example/Tree 01-05",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ol><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ol><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ol><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ol><li><a href=\"/.*/Example/Tree_21\" title=\"Example/Tree 21\">Example/Tree 21</a></li>\n<li><a href=\"/.*/Example/Tree_22\" title=\"Example/Tree 22\">Example/Tree 22</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>\n<ol><li><a href=\"/.*/Example/Tree_31\" title=\"Example/Tree 31\">Example/Tree 31</a></li>\n<li><a href=\"/.*/Example/Tree_32\" title=\"Example/Tree 32\">Example/Tree 32</a>\n<ol><li><a href=\"/.*/Example/Tree_321\" title=\"Example/Tree 321\">Example/Tree 321</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_33\" title=\"Example/Tree 33\">Example/Tree 33</a></li></ol></li></ol>\n</div>"
+					"div.srf-tree > ol > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ol > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ol > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ol > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ol > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ol > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ol > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					"div.srf-tree > ol > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ol > li:nth-child(1) > a[title=\"Example/Tree 21\"]:only-child",
+					"div.srf-tree > ol > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ol > li:nth-child(2) > a[title=\"Example/Tree 22\"]:only-child",
+
+					"div.srf-tree > ol > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ol > li:nth-child(1) > a[title=\"Example/Tree 31\"]:only-child",
+					"div.srf-tree > ol > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ol > li:nth-child(2) > a[title=\"Example/Tree 32\"] + ol > li:only-child > a[title=\"Example/Tree 321\"]:only-child",
+					"div.srf-tree > ol > li:nth-child(3) > a[title=\"Example/Tree 3\"] + ol > li:nth-child(3) > a[title=\"Example/Tree 33\"]:only-child",
+
+					[ "div.srf-tree > ol > li", 3 ],
+					[ "div.srf-tree > ol > li > ol > li", 8 ],
+					[ "div.srf-tree > ol > li > ol > li > ol > li", 2 ]
 				]
 			}
 		},
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 01-06 (Multi-page result with root specified (oltree))",
 			"subject": "Example/Tree 01-06",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ol><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ol><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ol><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ol></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ol></li></ol>\n</div>"
-				],
-				"not-contain": [
-					"Example/Tree 2",
-					"Example/Tree 3"
+					"div.srf-tree > ol > li:only-child > a[title=\"Example/Tree 2\"] + ol > li:nth-child(1) > a[title=\"Example/Tree 21\"]:only-child",
+					"div.srf-tree > ol > li:only-child > a[title=\"Example/Tree 2\"] + ol > li:nth-child(2) > a[title=\"Example/Tree 22\"]:only-child",
+					
+					[ "div.srf-tree > ol > li", 1 ],
+					[ "div.srf-tree > ol > li > ol > li", 2 ]
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-02.json
@@ -31,22 +31,32 @@
 	],
 	"tests": [
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 02-01 (Simple one-page result)",
 			"subject": "Example/Tree 02-01",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a></li></ul>\n</div>"
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 1\"]:only-child"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 02-02-1 (Simple one-page result with template - structure)",
+			"subject": "Example/Tree 02-02",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li:only-child > a[title=\"Example/Tree 1\"]:only-child"
 				]
 			}
 		},
 		{
 			"type": "parser",
-			"about": "Tree 02-02 (Simple one-page result with template)",
+			"about": "Tree 02-02-2 (Simple one-page result with template - content)",
 			"subject": "Example/Tree 02-02",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li>FOO<a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>BAR</li></ul>\n</div>"
+					"FOO.*Example/Tree 1.*BAR"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-04.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-04.json
@@ -18,12 +18,12 @@
 	],
 	"tests": [
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 04-01 (Empty resultset does not produce tree)",
 			"subject": "Example/Tree 04-01",
 			"assert-output": {
-				"not-contain": [
-					"<div class=\"srf-tree\">"
+				"to-contain": [
+					[ "div.srf-tree", 0 ]
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-06.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-06.json
@@ -55,22 +55,58 @@
 	],
 	"tests": [
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "Tree 06-01 (Insert elements with multiple parents multiple times)",
 			"subject": "Example/Tree 06-01",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li><a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>\n<ul><li><a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a></li>\n<li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a></li></ul></li>\n<li><a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>\n<ul><li><a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>\n<ul><li><a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a></li></ul></li></ul></li>\n<li><a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a></li></ul>\n</div>"
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:only-child > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"]:only-child",
+
+					[ "div.srf-tree > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li", 4 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 2 ]
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 06-02-1 (Insert elements with multiple parents multiple times (with template)) - structure",
+			"subject": "Example/Tree 06-02",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(1) > a[title=\"Example/Tree 11\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(2) > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+					"div.srf-tree > ul > li:nth-child(1) > a[title=\"Example/Tree 1\"] + ul > li:nth-child(3) > a[title=\"Example/Tree 13\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(2) > a[title=\"Example/Tree 2\"] + ul > li:only-child > a[title=\"Example/Tree 12\"] + ul > li:only-child > a[title=\"Example/Tree 121\"]:only-child",
+
+					"div.srf-tree > ul > li:nth-child(3) > a[title=\"Example/Tree 3\"]:only-child",
+
+					[ "div.srf-tree > ul > li", 3 ],
+					[ "div.srf-tree > ul > li > ul > li", 4 ],
+					[ "div.srf-tree > ul > li > ul > li > ul > li", 2 ]
 				]
 			}
 		},
 		{
 			"type": "parser",
-			"about": "Tree 06-02 (Insert elements with multiple parents multiple times (with template))",
+			"about": "Tree 06-02-2 (Insert elements with multiple parents multiple times (with template)) - content",
 			"subject": "Example/Tree 06-02",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"srf-tree\">\n<ul><li>FOO<a href=\"/.*/Example/Tree_1\" title=\"Example/Tree 1\">Example/Tree 1</a>BAR\n<ul><li>FOO<a href=\"/.*/Example/Tree_11\" title=\"Example/Tree 11\">Example/Tree 11</a>BAR</li>\n<li>FOO<a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>BAR\n<ul><li>FOO<a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a>BAR</li></ul></li>\n<li>FOO<a href=\"/.*/Example/Tree_13\" title=\"Example/Tree 13\">Example/Tree 13</a>BAR</li></ul></li>\n<li>FOO<a href=\"/.*/Example/Tree_2\" title=\"Example/Tree 2\">Example/Tree 2</a>BAR\n<ul><li>FOO<a href=\"/.*/Example/Tree_12\" title=\"Example/Tree 12\">Example/Tree 12</a>BAR\n<ul><li>FOO<a href=\"/.*/Example/Tree_121\" title=\"Example/Tree 121\">Example/Tree 121</a>BAR</li></ul></li></ul></li>\n<li>FOO<a href=\"/.*/Example/Tree_3\" title=\"Example/Tree 3\">Example/Tree 3</a>BAR</li></ul>\n</div>"
+					"FOO.*Example/Tree 1.*BAR",
+					"FOO.*Example/Tree 11.*BAR",
+					"FOO.*Example/Tree 12.*BAR",
+					"FOO.*Example/Tree 121.*BAR",
+					"FOO.*Example/Tree 13.*BAR",
+					"FOO.*Example/Tree 2.*BAR",
+					"FOO.*Example/Tree 3.*BAR"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/tree-07.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/tree-07.json
@@ -1,0 +1,139 @@
+{
+	"description": "Tree format: Simple one-page result",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has parent",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Part of",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "Example/Tree format template",
+			"contents": "FOO{{{1|}}}BAR{{{userparam|}}}BAZ"
+		},
+		{
+			"page": "Example/Tree 1",
+			"contents": "[[Part of::Tree test]]"
+		},
+		{
+			"page": "Example/Tree 11",
+			"contents": "[[Part of::Tree test]][[Has parent::Example/Tree 1]]"
+		},
+		{
+			"page": "Example/Tree 07-01",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent }}"
+		},
+		{
+			"page": "Example/Tree 07-02",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent |link=all}}"
+		},
+		{
+			"page": "Example/Tree 07-03",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent |link=subject}}"
+		},
+		{
+			"page": "Example/Tree 07-04",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent |link=none}}"
+		},
+		{
+			"page": "Example/Tree 07-05",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent |template=Example/Tree format template |userparam=someparam }}"
+		},
+		{
+			"page": "Example/Tree 07-06",
+			"contents": "{{#ask:[[Part of::Tree test]] |?Has parent |format=tree |parent=Has parent |template=Example/Tree format template |userparam=someparam |link=none}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser-html",
+			"about": "Tree 07-01 (Default linking)",
+			"subject": "Example/Tree 07-01",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li > a[title=\"Example/Tree 1\"] + ul > li > a[title=\"Example/Tree 11\"] + a[title=\"Property:Has parent\"] + a[title=\"Example/Tree 1\"]"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 07-02 (link=all)",
+			"subject": "Example/Tree 07-02",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li > a[title=\"Example/Tree 1\"] + ul > li > a[title=\"Example/Tree 11\"] + a[title=\"Property:Has parent\"] + a[title=\"Example/Tree 1\"]"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 07-03 (link=subject)",
+			"subject": "Example/Tree 07-03",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li > a[title=\"Example/Tree 1\"] + ul > li > a[title=\"Example/Tree 11\"]:first-of-type + a[title=\"Property:Has parent\"]:last-of-type"
+
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 07-04 (link=none)",
+			"subject": "Example/Tree 07-04",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li > ul:only-child > li > a[title=\"Property:Has parent\"]:only-child"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 07-05-1 (template with userparam)",
+			"subject": "Example/Tree 07-05",
+			"assert-output": {
+				"to-contain": [
+					"BARsomeparamBAZ"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "Tree 07-05-2 (template with userparam: assert intact default linking)",
+			"subject": "Example/Tree 07-05",
+			"assert-output": {
+				"to-contain": [
+					"div.srf-tree > ul > li > a[title=\"Example/Tree 1\"] + ul > li > a[title=\"Example/Tree 11\"]"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "Tree 07-06 (template with userparam and link=none)",
+			"subject": "Example/Tree 07-06",
+			"assert-output": {
+				"to-contain": [
+					"FOOExample/Tree 1BARsomeparamBAZ",
+					"FOOExample/Tree 11BARsomeparamBAZ"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR addresses or contains:
- Switch `tree` format JsonScript integration tests to use type `parser-html` instead of `parser` to test the html structure of the output rather exact equality of strings

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [ ] CI build passed
