### PR TITLE
Enable test coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - env: DB=mysql; MW=master; SMW=~3.0@dev
       php: 5.6
-    - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev
+    - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev; TYPE=coverage
       php: 7.0
     - env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
       php: 7.0

--- a/build/travis/run-tests.sh
+++ b/build/travis/run-tests.sh
@@ -4,11 +4,17 @@ set -ex
 BASE_PATH=$(pwd)
 MW_INSTALL_PATH=$BASE_PATH/../mw
 
+function uploadCoverageReport {
+	wget https://scrutinizer-ci.com/ocular.phar
+	php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+}
+
 cd $MW_INSTALL_PATH/extensions/SemanticResultFormats
 
 if [ "$TYPE" == "coverage" ]
 then
-	composer phpunit -- --coverage-clover $BASE_PATH/build/coverage.clover
+	composer phpunit -- --coverage-clover coverage.clover
+	uploadCoverageReport
 else
 	composer phpunit
 fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,10 @@
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">formats</directory>
+            <file>SemanticResultFormats.hooks.php</file>
+            <file>SemanticResultFormats.parser.php</file>
+            <file>SemanticResultFormats.php</file>
+            <file>SemanticResultFormats.utils.php</file>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -44,7 +44,6 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 	}
 
 	/**
-	 * @covers \SRF\Formats\Tree\TreeResultPrinter::getResult()
 	 */
 	public function testGetResult_NoParentProperty() {
 


### PR DESCRIPTION
This PR addresses enables test coverage reporting.

Before this is merged somebody should enable external code coverage on Scrutinizer. See https://scrutinizer-ci.com/docs/tools/external-code-coverage/

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed
