### PR TITLE
Fixed calendar rendering in IE

### DIFF
--- a/formats/calendar/resources/ext.srf.formats.eventcalendar.js
+++ b/formats/calendar/resources/ext.srf.formats.eventcalendar.js
@@ -418,7 +418,7 @@
 		/**
 		 * Handles redirect to a clicktarget URL.  
 		 */
-		onDayClick( date, data, clickPopup ){
+		onDayClick: function( date, data, clickPopup ){
 			var clicktarget = data.query.ask.parameters.clicktarget;
 			if( clicktarget !== 'none' ){
 				var h = date.getUTCHours() + 1;


### PR DESCRIPTION
Fixed syntax error in onDayClick function declaration.

When using the eventCalendar result format IE users are presented with an infinite loading spinner. 

The reason for this is that the JS function definition for the function "onDayClick" is syntactically incorrect and causes IE to choke. Specifically, it currently looks like:

`onDayClick( date, data, clickPopup )`

when it should instead be:

`onDayClick: function( date, data, clickPopup )`

