### PR TITLE
Timeline, fix resource loading

### DIFF
--- a/Resources.php
+++ b/Resources.php
@@ -516,9 +516,47 @@ return [
 	],
 
 	// Timeline
-	'ext.smile.timeline' => $formatModule + [
-		'scripts' => 'timeline/resources/SimileTimeline/timeline-api.js'
+	// Copied from timeline-api.js
+	'ext.smile.timeline.core' => $formatModule + [
+		'scripts' => [
+			'timeline/resources/SimileTimeline/scripts/timeline.js',
+			'timeline/resources/SimileTimeline/scripts/util/platform.js',
+			'timeline/resources/SimileTimeline/scripts/util/debug.js',
+			'timeline/resources/SimileTimeline/scripts/util/xmlhttp.js',
+			'timeline/resources/SimileTimeline/scripts/util/dom.js',
+			'timeline/resources/SimileTimeline/scripts/util/graphics.js',
+			'timeline/resources/SimileTimeline/scripts/util/date-time.js',
+			'timeline/resources/SimileTimeline/scripts/util/data-structure.js',
+			'timeline/resources/SimileTimeline/scripts/units.js',
+			'timeline/resources/SimileTimeline/scripts/themes.js',
+			'timeline/resources/SimileTimeline/scripts/ethers.js',
+			'timeline/resources/SimileTimeline/scripts/ether-painters.js',
+			'timeline/resources/SimileTimeline/scripts/labellers.js',
+			'timeline/resources/SimileTimeline/scripts/sources.js',
+			'timeline/resources/SimileTimeline/scripts/layouts.js',
+			'timeline/resources/SimileTimeline/scripts/painters.js',
+			'timeline/resources/SimileTimeline/scripts/decorators.js',
+			'timeline/resources/SimileTimeline/scripts/labellers.js',
+
+			// Keep this with in the same load sequence
+			'timeline/resources/SimileTimeline/scripts/l10n/en/labellers.js',
+			'timeline/resources/SimileTimeline/scripts/l10n/en/timeline.js'
+		],
+		'styles'  => [
+			'timeline/resources/SimileTimeline/styles/timeline.css',
+			'timeline/resources/SimileTimeline/styles/ethers.css',
+			'timeline/resources/SimileTimeline/styles/events.css',
+		],
+		'targets' => [ 'mobile', 'desktop' ]
 	],
+
+	'ext.smile.timeline' => $formatModule + [
+		'scripts' => [
+			'timeline/resources/SimileTimeline/timeline-api.js',
+		],
+		'targets' => [ 'mobile', 'desktop' ]
+	],
+
 	'ext.srf.timeline' => $formatModule + [
 		'scripts' => 'timeline/resources/ext.srf.timeline.js',
 		'dependencies' => [
@@ -526,6 +564,7 @@ return [
 			'mediawiki.legacy.wikibits'
 		],
 		'position' => 'top',
+		'targets' => [ 'mobile', 'desktop' ]
 	],
 
 	// D3

--- a/formats/timeline/SRF_Timeline.php
+++ b/formats/timeline/SRF_Timeline.php
@@ -79,11 +79,8 @@ class SRFTimeline extends SMWResultPrinter {
 		}
 
 		// print header
-		$link = $res->getQueryLink( wfMessage( 'srf-timeline-allresults' )->inContentLanguage()->text() );
-		$result = "<div id=\"smwtimeline-$id\" class=\"smwtimeline\" style=\"height: $this->m_tlsize\">";
-		$result .= '<span class="smwtlcomment">'
-			. wfMessage( 'srf-timeline-nojs' )->inContentLanguage()->escaped()
-			. ' ' . $link->getText( $outputmode, $this->mLinker ) . '</span>'; // note for people without JavaScript
+		$result = "<div id=\"smwtimeline-$id\" class=\"smwtimeline is-disabled\" style=\"height: $this->m_tlsize\">";
+		$result .= '<span class="smw-overlay-spinner medium" style="top:40%; transform: translate(-50%, -50%);"></span>';
 
 		foreach ( $this->m_tlbands as $band ) {
 			$result .= '<span class="smwtlband" style="display:none;">' . htmlspecialchars( $band ) . '</span>';
@@ -388,7 +385,7 @@ class SRFTimeline extends SMWResultPrinter {
 			'islist' => true,
 			'default' => [ 'MONTH', 'YEAR' ],
 			'message' => 'srf_paramdesc_timelinebands',
-			'values' => [ 'DECADE', 'YEAR', 'MONTH', 'WEEK', 'DAY', 'HOUR', 'MINUTE' ],
+			'values' => [ 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR', 'DECADE' ],
 		];
 
 		$params['template'] = [

--- a/formats/timeline/resources/ext.srf.timeline.js
+++ b/formats/timeline/resources/ext.srf.timeline.js
@@ -3,21 +3,25 @@
  * for inserting the required Simile scripts if needed.
  */
 
-var smwtl;
+( function( $, mw ) {
 
-jQuery(smw_timeline_init);
+	'use strict';
 
-function smw_timeline_init() {
-	if (!document.getElementsByName) return;
-	tbls = document.getElementsByTagName("div");
+	mw.loader.using( [ 'ext.smile.timeline', 'ext.smile.timeline.core' ] ).then( function () {
 
-	for (ti=0;ti<tbls.length;ti++) {
-		thisTbl = tbls[ti];
-		if (((' '+thisTbl.className+' ').indexOf("smwtimeline") != -1) && (thisTbl.id)) {
-			smw_make_timeline(thisTbl);
-		}
-	}
-}
+		$( document ).ready( function() {
+			$( '.smwtimeline' ).each( function() {
+
+				var context = $( this );
+				context.removeClass( 'is-disabled' );
+
+				smw_make_timeline( context[0] );
+			} );
+		} );
+
+	} );
+
+}( jQuery, mediaWiki ) );
 
 function smw_make_timeline(div) {
 	// extract relevant event data:
@@ -116,7 +120,7 @@ function smw_make_timeline(div) {
 		})
 	}
 
-	smwtl = Timeline.create(div, bandInfos);
+	Timeline.create(div, bandInfos);
 }
 
 function smw_get_bandwidth(number,count) {

--- a/tests/phpunit/Integration/JSONScript/TestCases/timeline-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/timeline-01.json
@@ -1,0 +1,50 @@
+{
+	"description": "Test for timeline result format",
+	"setup": [
+		{
+			"page": "Has date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Timeline/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Category:Timeline]]"
+		},
+		{
+			"page": "Example/Timeline/2",
+			"contents": "[[Has date::3 Jan 1970]] [[Category:Timeline]]"
+		},
+		{
+			"page": "Example/Timeline/Q.1",
+			"contents": "{{#ask: [[Category:Timeline]] |?Has date |format=timeline }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 default bands",
+			"subject": "Example/Timeline/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<div id=\"smwtimeline.* class=\"smwtimeline is-disabled\" style=\"height: 300px\">",
+					"<span class=\"smwtlband\" style=\"display:none;\">MONTH</span><span class=\"smwtlband\" style=\"display:none;\">YEAR</span>",
+					"<span class=\"smwtlurl\"><a .* title=\"Example/Timeline/1\">Example/Timeline/1</a></span><span class=\"smwtlstart\">1970-01-01</span>",
+					"<span class=\"smwtlurl\"><a .* title=\"Example/Timeline/2\">Example/Timeline/2</a></span><span class=\"smwtlstart\">1970-01-03</span>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #292, https://sourceforge.net/p/semediawiki/mailman/message/36008850/

This PR addresses or contains:

- https://github.com/SemanticMediaWiki/SemanticResultFormats/commit/9a2d405d28e18ef50cdda12996d3b260c29e2127 tried to tackle the loading issue in the past but it is believed that recent changes to the ResourceLoader requires a different approach
- Load each file explicitly as outlined in `timeline-api.js`
- Create a `Timeline` instance only after resources have been loaded to avoid a "Timeline.DefaultEventSource is not a constructor"
- Removes the misplaced  `srf-timeline-allresults` with the further results link as is shown even though the JS isn't loaded given a false impression on the current result display or where no further results are available.
- Adds an integration test (doesn't interact with JS, only ensures that data are exported as anticipated by the JS module)

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes: #292
