### PR TITLE
Fix filtered-02.json integration test

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/filtered-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/filtered-02.json
@@ -35,7 +35,7 @@
 			"assert-output": {
 				"to-be-valid-html": 1,
 				"to-contain": [
-					"div.filtered + span.smw-highlighter[data-title=\"Error\"][title='No map provider specified for \"map\" view.']"
+					"div.filtered + span.smw-highlighter[data-title=\"Warning\"][title='No map provider specified for \"map\" view.']"
 				]
 			}
 		}


### PR DESCRIPTION
This PR is made in reference to: # https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/2691

This PR addresses or contains:

- The particular type now carries the correct `Warning` label with an error severity denoting a different code 

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
