### PR TITLE
Remove deprecated ApiResultPrinter, refs 317

### DIFF
--- a/formats/calendar/EventCalendar.php
+++ b/formats/calendar/EventCalendar.php
@@ -2,7 +2,8 @@
 
 namespace SRF;
 
-use SMW\ApiResultPrinter;
+use SMW\ResultPrinter;
+use SMWQueryResult as QueryResult;
 use Html;
 
 /**
@@ -24,59 +25,23 @@ use Html;
  *
  * @ingroup QueryPrinter
  */
-class EventCalendar extends ApiResultPrinter {
+class EventCalendar extends ResultPrinter {
 
 	/**
-	 * Corresponding message name
+	 * @see ResultPrinter::getName
 	 *
+	 * {@inheritDoc}
 	 */
 	public function getName() {
 		return $this->msg( 'srf-printername-eventcalendar' )->text();
 	}
 
 	/**
-	 * Prepare html output
-	 *
-	 * @since 1.9
-	 *
-	 * @param array $data
-	 * @return string
-	 */
-	protected function getHtml( array $data ) {
-
-		// Init
-		$this->isHTML = true;
-		$id = $this->getId();
-
-		// Add options
-		$data['version'] = '0.8.0';
-
-		// Encode data object
-		$this->encode( $id, $data );
-
-		// Init RL module
-		$this->addResources( 'ext.srf.eventcalendar' );
-
-		// Element includes info, spinner, and container placeholder
-		return Html::rawElement(
-			'div',
-			[ 'class' => 'srf-eventcalendar', 'data-external-class' => ( $this->params['class'] ? $this->params['class'] : '' ) ],
-				Html::element( 'div', [ 'class' => 'srf-top' ], '' ) .  $this->loading() . Html::element(
-				'div',
-				[ 'id' => $id, 'class' => 'srf-container', 'style' => 'display:none;' ],
-				''
-			)
-		);
-	}
-
-	/**
-	 * @see SMWResultPrinter::getParamDefinitions
+	 * @see ResultPrinter::getParamDefinitions
 	 *
 	 * @since 1.8
 	 *
-	 * @param $definitions array of IParamDefinition
-	 *
-	 * @return array of IParamDefinition|array
+	 * {@inheritDoc}
 	 */
 	public function getParamDefinitions( array $definitions ) {
 		$params = parent::getParamDefinitions( $definitions );
@@ -125,7 +90,55 @@ class EventCalendar extends ApiResultPrinter {
 		$params['clicktarget'] = [
 			'message' => 'srf-paramdesc-clicktarget',
 			'default' => 'none'
-		];		
+		];
+
 		return $params;
 	}
+
+	/**
+	 * @see ResultPrinter::getResultText
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function getResultText( QueryResult $res, $outputmode ) {
+
+		$resourceFormatter = new ResourceFormatter();
+		$data = $resourceFormatter->getData( $res, $outputmode, $this->params );
+
+		$this->isHTML = true;
+		$id = $resourceFormatter->session();
+
+		// Add options
+		$data['version'] = '0.8.0';
+
+		// Encode data object
+		$resourceFormatter->encode( $id, $data );
+
+		// Init RL module
+		$resourceFormatter->registerResources( [ 'ext.srf.eventcalendar' ] );
+
+		// Element includes info, spinner, and container placeholder
+		return Html::rawElement(
+			'div',
+			[
+				'class' => 'srf-eventcalendar',
+				'data-external-class' => ( $this->params['class'] ? $this->params['class'] : '' )
+			],
+			Html::element(
+				'div',
+				[
+					'class' => 'srf-top'
+				],
+				''
+			) .  $resourceFormatter->placeholder() . Html::element(
+				'div',
+				[
+					'id' => $id,
+					'class' => 'srf-container',
+					'style' => 'display:none;'
+				]
+			)
+		);
+	}
+
 }

--- a/formats/calendar/resources/ext.srf.formats.eventcalendar.js
+++ b/formats/calendar/resources/ext.srf.formats.eventcalendar.js
@@ -416,7 +416,7 @@
 			}
 		},
 		/**
-		 * Handles redirect to a clicktarget URL.  
+		 * Handles redirect to a clicktarget URL.
 		 */
 		onDayClick: function( date, data, clickPopup ){
 			var clicktarget = data.query.ask.parameters.clicktarget;
@@ -425,7 +425,7 @@
 				var m = date.getUTCMinutes();
 				var s = date.getUTCSeconds();
 				var hms;
-				
+
 				if( h == 24 ){
 					// avoid switch to next day
 					hms  = "T"+ "13" + ":" + m + ":" + s;
@@ -437,18 +437,18 @@
 										 .replace( /%clickmonth%/g, date.getMonth() + 1 )
 										 .replace( /%clickday%/g, date.getDate() )
 										 .replace( /%clicktime%/g, hms );
-				
+
 				var wgArticlePath = mw.config.get( 'wgArticlePath' ).replace( '$1', '' ).trim();
 				var wgServer = mw.config.get( 'wgServer' );
 
 				var clicktargetURL = wgServer + wgArticlePath + clicktarget;
 				/* DONE: i18n */
-				var r = confirm( clickPopup.popup );  
+				var r = confirm( clickPopup.popup );
 				if ( r == true ){
 					window.open( clicktargetURL, '_self' );
-				}   
-		   } 
-			
+				}
+		   }
+
 		},
 		/**
 		 * Handles fullCalendar tasks
@@ -506,8 +506,8 @@
 							if ( allDay && data.query.ask.parameters.dayview && $( jsEvent.target ).is( 'div.fc-day-number' ) ) {
 								container.fullCalendar( 'changeView', 'agendaDay'/* or 'basicDay' */).fullCalendar( 'gotoDate', date );
 							} else {
-								// redirect to a clicktarget URL if defined. 
-								 self.onDayClick( date, data, self.messages.clickPopup );	   
+								// redirect to a clicktarget URL if defined.
+								 self.onDayClick( date, data, self.messages.clickPopup );
 							}
 						}
 					} );
@@ -915,8 +915,17 @@
 					'offset': data.query.ask.parameters.offset
 				};
 
+			if ( data.query.ask.parameters.hasOwnProperty( 'sort' ) ) {
+				parameters.sort = data.query.ask.parameters.sort;
+			};
+
+			if ( data.query.ask.parameters.hasOwnProperty( 'order' ) ) {
+				parameters.order = data.query.ask.parameters.order;
+			};
+
 			// Stringify the query
 			var query = new smw.query( printouts, parameters, conditions ).toString();
+
 			var startDate = new Date();
 			srf.log( 'Query: ' + query );
 

--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -1,7 +1,10 @@
 <?php
 
 namespace SRF;
-use SMW, Html;
+
+use SMW\ResultPrinter;
+use SMWQueryResult as QueryResult;
+use Html;
 
 /**
  * DataTables and SMWAPI.
@@ -11,64 +14,23 @@ use SMW, Html;
  *
  * @author mwjames
  */
-class DataTables extends SMW\ApiResultPrinter {
+class DataTables extends ResultPrinter {
 
 	/**
-	 * Corresponding message name
+	 * @see ResultPrinter::getName
 	 *
+	 * {@inheritDoc}
 	 */
 	public function getName() {
 		return $this->msg( 'srf-printername-datatables' )->text();
 	}
 
 	/**
-	 * Prepare html output
-	 *
-	 * @since 1.9
-	 *
-	 * @param array $data
-	 * @return string
-	 */
-	protected function getHtml( array $data ) {
-
-		// Init
-		$this->isHTML = true;
-		$id = $this->getId();
-
-		// Add options
-		$data['version'] = '0.2.5';
-
-		// Encode data object
-		$this->encode( $id, $data );
-
-		// Init RL module
-		$this->addResources( 'ext.srf.datatables' );
-
-		// Element includes info, spinner, and container placeholder
-		return Html::rawElement( 'div', [
-				'class' => 'srf-datatables' . ( $this->params['class'] ? ' ' . $this->params['class'] : '' ),
-				'data-theme' => $this->params['theme'],
-			], Html::element( 'div', [
-					'class' => 'top'
-					]
-				) . $this->loading() .
-				Html::element( 'div', [
-					'id' => $id,
-					'class' => 'container',
-					'style' => 'display:none;'
-					]
-				)
-		);
-	}
-
-	/**
-	 * @see SMWResultPrinter::getParamDefinitions
+	 * @see ResultPrinter::getParamDefinitions
 	 *
 	 * @since 1.8
 	 *
-	 * @param $definitions array of IParamDefinition
-	 *
-	 * @return array of IParamDefinition|array
+	 * {@inheritDoc}
 	 */
 	public function getParamDefinitions( array $definitions ) {
 		$params = parent::getParamDefinitions( $definitions );
@@ -86,4 +48,51 @@ class DataTables extends SMW\ApiResultPrinter {
 
 		return $params;
 	}
+
+	/**
+	 * @see ResultPrinter::getResultText
+	 *
+	 * {@inheritDoc}
+	 */
+	protected function getResultText( QueryResult $res, $outputmode ) {
+
+		$resourceFormatter = new ResourceFormatter();
+		$data = $resourceFormatter->getData( $res, $outputmode, $this->params );
+
+		$this->isHTML = true;
+		$id = $resourceFormatter->session();
+
+		// Add options
+		$data['version'] = '0.2.5';
+
+		// Encode data object
+		$resourceFormatter->encode( $id, $data );
+
+		// Init RL module
+		$resourceFormatter->registerResources( [ 'ext.srf.datatables' ] );
+
+		// Element includes info, spinner, and container placeholder
+		return Html::rawElement(
+			'div',
+			[
+				'class' => 'srf-datatables' . ( $this->params['class'] ? ' ' . $this->params['class'] : '' ),
+				'data-theme' => $this->params['theme'],
+			],
+			Html::element(
+				'div',
+				[
+					'class' => 'top'
+				],
+				''
+			) . $resourceFormatter->placeholder() .	Html::element(
+				'div',
+				[
+					'id' => $id,
+					'class' => 'container',
+					'style' => 'display:none;'
+				]
+			)
+		);
+	}
+
 }

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SRF;
+
+use Html;
+use SMWOutputs as ResourceManager;
+use SMWQueryResult as QueryResult;
+
+/**
+ * @since 3.0
+ *
+ * @license GNU GPL v2 or later
+ * @author mwjames
+ */
+class ResourceFormatter {
+
+	/**
+	 * @since 3.0
+	 *
+	 * @param array $modules
+	 * @param array $styleModules
+	 */
+	public static function registerResources( array $modules = [], array $styleModules = [] ) {
+
+		foreach ( $modules as $module ) {
+			ResourceManager::requireResource( $module );
+		}
+
+		foreach ( $styleModules as $styleModule ) {
+			ResourceManager::requireStyle( $styleModule );
+		}
+	}
+
+	/**
+	 * @since 3.0
+	 *
+	 * @return string
+	 */
+	public static function session() {
+		return 'smw-' . uniqid();
+	}
+
+	/**
+	 * Convenience method generating a visual placeholder before any
+	 * JS is registered to indicate that resources (JavaScript, CSS)
+	 * are being loaded and once ready ensure to set
+	 * ( '.smw-spinner' ).hide()
+	 *
+	 * @since 3.0
+	 */
+	public static function placeholder() {
+		self::registerResources( [], [ 'ext.smw.style' ] );
+
+		return Html::rawElement(
+			'div',
+			array( 'class' => 'smw-spinner left mw-small-spinner' ),
+			Html::element(
+				'p',
+				array( 'class' => 'text' ),
+				wfMessage( 'smw-livepreview-loading' )->text()
+			)
+		);
+	}
+
+	/**
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $id
+	 * @param array $data
+	 */
+	public static function encode( $id, $data ) {
+		ResourceManager::requireHeadItem(
+			$id,
+			\Skin::makeVariablesScript(
+				[
+					$id => json_encode( $data )
+				]
+			)
+		);
+	}
+
+	/**
+	 * @param QueryResult $queryResult
+	 * @param $outputMode
+	 *
+	 * @return string
+	 */
+	public static function getData( QueryResult $queryResult, $outputMode, $parameters = [] ) {
+
+		// Add parameters that are only known to the specific printer
+		$ask = $queryResult->getQuery()->toArray();
+
+		foreach ( $parameters as $key => $value ) {
+			if ( is_string( $value ) || is_integer( $value ) || is_bool( $value ) ) {
+				$ask['parameters'][$key] = $value;
+			}
+		}
+
+		// Combine all data into one object
+		$data = array(
+			'query' => array(
+				'result' => $queryResult->toArray(),
+				'ask'    => $ask
+			)
+		);
+
+		return $data;
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/datatables-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/datatables-01.json
@@ -1,0 +1,47 @@
+{
+	"description": "Test `format=datatables` html output (no JS validation)",
+	"setup": [
+		{
+			"page": "Has date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Datatables/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Category:Datatables]]"
+		},
+		{
+			"page": "Example/Datatables/2",
+			"contents": "[[Has date::3 Jan 1970]] [[Category:Datatables]]"
+		},
+		{
+			"page": "Test/Datatables/Q.1",
+			"contents": "{{#ask: [[Category:Datatables]] |?Has date |format=datatables }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Test/Datatables/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-datatables\" data-theme=\"bootstrap\"><div class=\"top\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/eventcalendar-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/eventcalendar-01.json
@@ -1,0 +1,47 @@
+{
+	"description": "Test `format=eventcalendar` html output (no JS validation)",
+	"setup": [
+		{
+			"page": "Has date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Eventcalendar/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Category:Eventcalendar]]"
+		},
+		{
+			"page": "Example/Eventcalendar/2",
+			"contents": "[[Has date::3 Jan 1970]] [[Category:Eventcalendar]]"
+		},
+		{
+			"page": "Test/Eventcalendar/Q.1",
+			"contents": "{{#ask: [[Category:Eventcalendar]] |?Has date |format=eventcalendar }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Test/Eventcalendar/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-eventcalendar\" data-external-class=\"\">"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/ResourceFormatterTest.php
+++ b/tests/phpunit/Unit/ResourceFormatterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SRF\Tests;
+
+use SRF\ResourceFormatter;
+
+/**
+ * @covers \SRF\ResourceFormatter
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.0
+ *
+ * @author mwjames
+ */
+class ResourceFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testSession() {
+
+		$this->assertContains(
+			'smw-',
+			ResourceFormatter::session()
+		);
+	}
+
+	public function testPlaceholder() {
+
+		$this->assertInternalType(
+			'string',
+			ResourceFormatter::placeholder()
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #317 

This PR addresses or contains:

- Removes the deprecated `ApiResultPrinter` and moves required methods to a local `ResourceFormatter` (maybe there is a better name but for the 10 min. I worked on this, nothing popped my mind)
- Fixes #317  through the use of `ResourceFormatter`
- Adds a simple integration tests for `format=datatables` and `format=eventcalendar` to detect issues like an incompatible method access that caused #317

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes: #317