### PR TITLE
Load exhibit map assets over HTTPS

### DIFF
--- a/formats/Exhibit/exhibit/extensions/map/map-extension-bundle.css
+++ b/formats/Exhibit/exhibit/extensions/map/map-extension-bundle.css
@@ -6,5 +6,5 @@ div.exhibit-mapView-map {
     border: 1px solid #738699;
 }
 .olPopupCloseBox {
-    background: transparent url(http://api.simile-widgets.org/ajax/2.2.1/images/close-button.png) no-repeat scroll 0 0 ! important;
+    background: transparent url(https://api.simile-widgets.org/ajax/2.2.1/images/close-button.png) no-repeat scroll 0 0 ! important;
 }

--- a/formats/Exhibit/exhibit/extensions/map/styles/olmap-view.css
+++ b/formats/Exhibit/exhibit/extensions/map/styles/olmap-view.css
@@ -1,3 +1,3 @@
 .olPopupCloseBox {
-    background: transparent url(http://api.simile-widgets.org/ajax/2.2.1/images/close-button.png) no-repeat scroll 0 0 ! important;
+    background: transparent url(https://api.simile-widgets.org/ajax/2.2.1/images/close-button.png) no-repeat scroll 0 0 ! important;
 }


### PR DESCRIPTION
This PR addresses or contains:
- Some assets in Exhibit are always loaded over HTTP. This can cause mixedcontent issues if the wiki is using HTTPS. This change ensures the assets are always loaded over HTTPS.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [x] CI build passed
