### PR TITLE
Remove `default` from earliest, latest, refs 344

### DIFF
--- a/formats/time/SRF_Time.php
+++ b/formats/time/SRF_Time.php
@@ -90,12 +90,6 @@ class SRFTime extends SMWResultPrinter {
 			'message' => 'srf_paramdesc_limit',
 		];
 
-		$params['default'] = [
-			'type' => 'integer',
-			'default' => '',
-			'message' => 'srf-paramdesc-default',
-		];
-
 		return $params;
 	}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/earliest-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/earliest-01.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test for `format=earliest`",
+	"setup": [
+		{
+			"page": "Has date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Earliest/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Category:Earliest]]"
+		},
+		{
+			"page": "Example/Earliest/2",
+			"contents": "[[Has date::3 Jan 1970]] [[Category:Earliest]]"
+		},
+		{
+			"page": "Example/Earliest/Q.1",
+			"contents": "{{#ask: [[Category:Earliest]] |?Has date |format=earliest }}"
+		},
+		{
+			"page": "Example/Earliest/Q.2",
+			"contents": "{{#ask: [[Category:Earliest/default]] |?Has date |format=earliest |default=No date }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/Earliest/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"1 January 1970"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 default output",
+			"subject": "Example/Earliest/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"No date"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/latest-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/latest-01.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test for `format=latest`",
+	"setup": [
+		{
+			"page": "Has date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Latest/1",
+			"contents": "[[Has date::1 Jan 1970]] [[Category:Latest]]"
+		},
+		{
+			"page": "Example/Latest/2",
+			"contents": "[[Has date::3 Jan 1970]] [[Category:Latest]]"
+		},
+		{
+			"page": "Example/Latest/Q.1",
+			"contents": "{{#ask: [[Category:Latest]] |?Has date |format=latest }}"
+		},
+		{
+			"page": "Example/Latest/Q.2",
+			"contents": "{{#ask: [[Category:Latest/default]] |?Has date |format=latest |default=No date }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0",
+			"subject": "Example/Latest/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"3 January 1970"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 default output",
+			"subject": "Example/Latest/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"No date"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #344

This PR addresses or contains:

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes: #344