### PR TITLE
Maintenance on messages

### DIFF
--- a/Resources.php
+++ b/Resources.php
@@ -36,7 +36,7 @@ $calendarMessages = [ 'messages' => [
 		'srf-ui-tooltip-title-legend', 'srf-ui-tooltip-title-filter',
 		'srf-ui-common-label-refresh', 'srf-ui-eventcalendar-label-update-success',
 		'srf-ui-eventcalendar-label-update-error', 'srf-ui-common-label-parameters',
-		'srf-ui-common-label-paneview', 'smw_qui_limt', 'srf-ui-common-label-daterange',
+		'srf-ui-common-label-paneview', 'srf-ui-common-label-daterange',
 		'srf-ui-eventcalendar-click-popup',
 	]
 ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -40,6 +40,7 @@
 	"srf-error-option-mix": "Option ($1) is not available",
 	"srf-error-option-link-all": "Option ($1) requires parameter \"link\" to be set \"all\"",
 	"srf-error-missing-layout": "The chart or graph cannot be shown because the layout is missing.",
+	"srf-error-jqplot-bubble-data-length": "The chart or graph cannot be shown because data are missing.",
 	"srf-error-jqplot-stackseries-data-length": "The chart or graph cannot be shown because not every bar or line has the same amount of elements.",
 	"srf-warn-empy-chart": "The chart or graph is empty due to missing data",
 	"srfc_previousmonth": "Previous month",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -57,6 +57,7 @@
 	"srf-error-option-mix": "This is an error message. Parameters:\n* $1 is a fixed entity name (name of the option) that cannot and should not be translated.",
 	"srf-error-option-link-all": "{{doc-important|Do not translate the parameter \"link\" and its possible value \"all\".}}\nThis is an error message. Parameters:\n* $1 is a fixed entitity name that cannot and should not be translated.",
 	"srf-error-missing-layout": "This is an error message.",
+	"srf-error-jqplot-bubble-data-length": "This is an error message.",
 	"srf-error-jqplot-stackseries-data-length": "This is an error message.",
 	"srf-warn-empy-chart": "This is an informatory message.",
 	"srfc_previousmonth": "A label describing a navigation control component.",


### PR DESCRIPTION
This PR is made in reference to: -

This PR addresses or contains:
- srf-error-jqplot-bubble-data-length was missing (added in bfe3e83a but not defined)
- smw_qui_limt is unused in SRF and removed from SMW since 6f7625f

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed
