### PR TITLE
Update for new GraphViz extension class structure

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@ This is not a release yet.
 * (#248) Fixed localized formatting of math results (by James Hong Kong)
 * Provided translation updates (by translatewiki.net community)
 * [#314](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/314) Moved `vCard` to the `SRF\vCard` namespace together with some unit and integration tests (by James Hong Kong)
+* [#365](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/365) Update for new versions of the GraphViz extension
 
 ## SRF 2.5.4
 

--- a/formats/graphviz/SRF_Graph.php
+++ b/formats/graphviz/SRF_Graph.php
@@ -93,7 +93,10 @@ class SRFGraph extends SMWResultPrinter {
 	}
 	
 	protected function getResultText( SMWQueryResult $res, $outputmode ) {
-		if ( !is_callable( 'GraphViz::graphvizParserHook' ) ) {
+		global $wgParser;
+		if ( !class_exists( 'GraphViz' )
+			&& !class_exists( '\\MediaWiki\\Extension\\GraphViz\\GraphViz' )
+		) {
 			wfWarn( 'The SRF Graph printer needs the GraphViz extension to be installed.' );
 			return '';
 		}
@@ -112,7 +115,7 @@ class SRFGraph extends SMWResultPrinter {
 		$graphInput .= "}";
 		
 		// Calls graphvizParserHook function from MediaWiki GraphViz extension
-		$result = GraphViz::graphvizParserHook( $graphInput, "", $GLOBALS['wgParser'], "" );
+		$result = $wgParser->recursiveTagParse( "<graphviz>$graphInput</graphviz>" );
 		
 		if ( $this->m_graphLegend && $this->m_graphColor ) {
 			$arrayCount = 0;


### PR DESCRIPTION
This PR is made in reference to: https://phabricator.wikimedia.org/T181926

This PR addresses or contains:
- Adds extra check for whether the GraphViz extension is loaded.
- Parses the graphviz source in a more future-compatible way (i.e. the `<graphviz>` element, rather than directly calling the render method).

This PR includes:
- [x] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [x] CI build passed
