### PR TITLE
Provide missing system messages

### DIFF
--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -644,12 +644,12 @@ END;
 		];
 
 		$params['template'] = [
-			'message' => 'srf-paramdesc-template',
+			'message' => 'smw-paramdesc-template',
 			'default' => '',
 		];
 
 		$params['userparam'] = [
-			'message' => 'srf-paramdesc-userparam',
+			'message' => 'smw-paramdesc-userparam',
 			'default' => '',
 		];
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -43,6 +43,7 @@
 	"srf-error-jqplot-bubble-data-length": "The chart or graph cannot be shown because data are missing.",
 	"srf-error-jqplot-stackseries-data-length": "The chart or graph cannot be shown because not every bar or line has the same amount of elements.",
 	"srf-warn-empy-chart": "The chart or graph is empty due to missing data",
+	"srf-paramdesc-color": "The color to mark calendar entries",
 	"srfc_previousmonth": "Previous month",
 	"srfc_nextmonth": "Next month",
 	"srfc_today": "Today",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -60,6 +60,7 @@
 	"srf-error-jqplot-bubble-data-length": "This is an error message.",
 	"srf-error-jqplot-stackseries-data-length": "This is an error message.",
 	"srf-warn-empy-chart": "This is an informatory message.",
+	"srf-paramdesc-color": "{{doc-paramdesc|color}}",
 	"srfc_previousmonth": "A label describing a navigation control component.",
 	"srfc_nextmonth": "A label describing a navigation control component.",
 	"srfc_today": "A label describing a navigation control component.\n{{Identical|Today}}",


### PR DESCRIPTION
This PR is made in reference to: #353 

This PR addresses or contains:
- reuses "smw-paramdesc-template" and "smw-paramdesc-userparam" for the missing "srf-paramdesc-userparam" and "srf-paramdesc-template" which is acceptable since SRF is directly dependant on SMW
- adds "srf-paramdesc-color" including documentation 

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [ ] CI build passed
