### PR TITLE
Filtered format: select2 list elements rendering outside of containing element

### DIFF
--- a/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
+++ b/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
@@ -69,10 +69,6 @@
 		}
 	}
 
-	.select2-container .select2-search--inline {
-		float: none;
-	}
-
 	.select2-search__field {
 		width: 100% !important;
 	}


### PR DESCRIPTION
Remove selector for .select2-container .select2-search--inline, which was causing select2 elements to render incorrectly.

This PR is made in reference to: #373
