### PR TITLE
Fixes result printers still using the Google Chart API via http

### DIFF
--- a/formats/googlecharts/README
+++ b/formats/googlecharts/README
@@ -1,12 +1,18 @@
 Google Charts are query printers for Semantic MediaWiki applying the Google Charts API
 documented at https://developers.google.com/chart/image/
 
+Important notes:
+* You must not forget that every time a user comes to a page embedding a Google chart,
+Google gets a ping. Moreover your data is being sent to Google in order to render it.
+!! The creator of Semantic Result Formats have not control over and cannot take any
+responsibility in case of any misuse resulting from this !!
+* As of April 20, 2012 the Google Charts API is deprecated and may be shut down
+without further notice. Thus you are advised to not rely on these two formats.
+* Do not forget also that these printers do not work offline, if you have a local wiki. 
+
 Currently two query printers are available for bar and pie charts. For up-to-date
 documentation, please refer to:
 * https://www.semantic-mediawiki.org/wiki/Help:Google_bar_format for the Google bar format
 * https://www.semantic-mediawiki.org/wiki/Help:Google_pie_format for the Google pie format
-
-Note: As of April 20, 2012 the Google Charts API is deprecated and may be shut down
-without further notice. Thus you are advised to not rely on these two formats.
 
 Semantic Result Formats provides these two legacy result printers for your convenience.

--- a/formats/googlecharts/README
+++ b/formats/googlecharts/README
@@ -1,8 +1,12 @@
-Google Charts are query printers for Semantic MediaWiki applying the
-Google Charts API at http://code.google.com/apis/chart
+Google Charts are query printers for Semantic MediaWiki applying the Google Charts API
+documented at https://developers.google.com/chart/image/
 
-Currently they include two query printers, for bar and pie charts.
+Currently two query printers are available for bar and pie charts. For up-to-date
+documentation, please refer to:
+* https://www.semantic-mediawiki.org/wiki/Help:Google_bar_format for the Google bar format
+* https://www.semantic-mediawiki.org/wiki/Help:Google_pie_format for the Google pie format
 
-For up-to-date documentation, please refer to:
+Note: As of April 20, 2012 the Google Charts API is deprecated and may be shut down
+without further notice. Thus you are advised to not rely on these two formats.
 
-https://www.mediawiki.org/wiki/Extension:Semantic_Result_Formats/googlebar_and_googlepie_formats
+Semantic Result Formats provides these two legacy result printers for your convenience.

--- a/formats/googlecharts/SRF_GoogleBar.php
+++ b/formats/googlecharts/SRF_GoogleBar.php
@@ -66,7 +66,7 @@ class SRFGoogleBar extends SMWResultPrinter {
 		$bardistance = 4; // distance between two bars
 		$height = $count * ( $barwidth + $bardistance ) + 15; // calculates the height of the image
 		
-		return 	'<img src="http://chart.apis.google.com/chart?cht=bhs&chbh=' . $barwidth . ',' . $bardistance . '&chs=' . $this->m_width . 'x' . $height . '&chds=0,' . $max . '&chd=t:' . $t . '&chxt=y&chxl=0:|' . $n . '" width="' . $this->m_width . '" height="' . $height . '" />';
+		return 	'<img src="https://chart.apis.google.com/chart?cht=bhs&chbh=' . $barwidth . ',' . $bardistance . '&chs=' . $this->m_width . 'x' . $height . '&chds=0,' . $max . '&chd=t:' . $t . '&chxt=y&chxl=0:|' . $n . '" width="' . $this->m_width . '" height="' . $height . '" />';
 
 	}
 

--- a/formats/googlecharts/SRF_GooglePie.php
+++ b/formats/googlecharts/SRF_GooglePie.php
@@ -61,7 +61,7 @@ class SRFGooglePie extends SMWResultPrinter {
 			}
 		}
 		
-		return 	'<img src="http://chart.apis.google.com/chart?cht=p3&chs=' . $this->m_width . 'x' . $this->m_height . '&chds=0,' . $max . '&chd=t:' . $t . '&chl=' . $n . '" width="' . $this->m_width . '" height="' . $this->m_height . '"  />';
+		return 	'<img src="https://chart.apis.google.com/chart?cht=p3&chs=' . $this->m_width . 'x' . $this->m_height . '&chds=0,' . $max . '&chd=t:' . $t . '&chl=' . $n . '" width="' . $this->m_width . '" height="' . $this->m_height . '"  />';
 	}
 
 	/**


### PR DESCRIPTION
This PR is made in reference to: #378 

This PR addresses or contains:
- Makes Google pie format use the Google Chart API via https
- Makes Google chart format use the Google Chart API via https
- Updates the respective documentation

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #378 