### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ composer.phar
 npm-debug.log
 
 vendor/
-extensions/
 node_modules/


### PR DESCRIPTION
This PR is made in reference to: #377 

This PR addresses or contains:
- Removes the `extensions/` subdirectory

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes: #377