### PR TITLE
Correctly format whole-hour timezones west of UTC

### DIFF
--- a/src/iCalendar/IcalTimezoneFormatter.php
+++ b/src/iCalendar/IcalTimezoneFormatter.php
@@ -175,7 +175,7 @@ class IcalTimezoneFormatter {
 	 * @param int $offset
 	 */
 	private function formatTimezoneOffset( $offset ) {
-		return sprintf('%s%02d%02d', $offset >= 0 ? '+' : '', floor($offset), ($offset - floor($offset)) * 60);
+		return sprintf('%s%02d%02d', $offset >= 0 ? '+' : '-', abs(floor($offset)), ($offset - floor($offset)) * 60);
 	}
 
 }

--- a/tests/phpunit/Unit/iCalendar/IcalTimezoneFormatterTest.php
+++ b/tests/phpunit/Unit/iCalendar/IcalTimezoneFormatterTest.php
@@ -51,12 +51,16 @@ class IcalTimezoneFormatterTest extends \PHPUnit_Framework_TestCase {
 
 		// DTSTART can be different pending the OS hence use .*
 
-		yield [
+		return [[
 			'UTC',
 			1,
 			2,
 			"BEGIN:VTIMEZONE\r\nTZID:UTC\r\nBEGIN:STANDARD\r\nDTSTART:.*\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nTZNAME:UTC\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n"
-		];
+		], [
+			'America/New_York',
+			1,
+			2,
+			"BEGIN:VTIMEZONE\r\nTZID:UTC\r\nBEGIN:STANDARD\r\nDTSTART:.*\r\nTZOFFSETFROM:-0400\r\nTZOFFSETTO:-0400\r\nTZNAME:UTC\r\nEND:STANDARD\r\nEND:VTIMEZONE\r\n"
+		]];
 	}
-
 }


### PR DESCRIPTION
The change *seems* OK to me, but I wasn't able to run the unit tests locally and it isn't clear from the Travis output what might be wrong.

I'd love some guidance on this, otherwise feel free to close this PR.

(the next step would be to add a test with the `America/St_Johns` timezone, as I suspect there is an `abs` needed there as well, but I wanted to make one change at a time)