### PR TITLE
Account for CSP nounce, refs 397

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -44,7 +44,7 @@ final class SRFUtils {
 		];
 
 		$requireHeadItem =  [ 'srf.options' => $options ];
-		SMWOutputs::requireHeadItem( 'srf.options', Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( 'srf.options', Skin::makeVariablesScript( $requireHeadItem, false ) );
 	}
 
 	/**

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -70,7 +70,8 @@ class ResourceFormatter {
 			\Skin::makeVariablesScript(
 				[
 					$id => json_encode( $data )
-				]
+				],
+				false
 			)
 		);
 	}


### PR DESCRIPTION
This PR is made in reference to: #397 

This PR addresses or contains:

- Objective of CSP (https://www.mediawiki.org/wiki/Content_Security_Policy) seems unclear and how this relates to `ResourceLoader::makeInlineScript` hence making a conjecture and setting it to `false`.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes  #397 
