### PR TITLE
Fix typo in file jquery.blockUI.js

### DIFF
--- a/resources/jquery/jquery.blockUI.js
+++ b/resources/jquery/jquery.blockUI.js
@@ -192,7 +192,7 @@
 			// enable if you want key and mouse events to be disabled for content that is blocked
 			bindEvents: true,
 
-			// be default blockUI will supress tab navigation from leaving blocking content
+			// be default blockUI will suppress tab navigation from leaving blocking content
 			// (if bindEvents is true)
 			constrainTabKey: true,
 
@@ -287,7 +287,7 @@
 			var z = opts.baseZ;
 
 			// blockUI uses 3 layers for blocking, for simplicity they are all used on every platform;
-			// layer1 is the iframe layer which is used to supress bleed through of underlying content
+			// layer1 is the iframe layer which is used to suppress bleed through of underlying content
 			// layer2 is the overlay layer which has opacity and a wait cursor (by default)
 			// layer3 is the message content that is displayed while blocking
 			var lyr1, lyr2, lyr3, s;


### PR DESCRIPTION
Update typo supress -->> suppress in file jquery.blockUI.js

Part of fixing typos in code of SemanticMediaWiki and extensions for it tracked in task https://phabricator.wikimedia.org/T201491 at Wikimedia Phabricator.