### PR TITLE
Fix typo 'becuase' in jqplot.pyramidRenderer.js file

### DIFF
--- a/resources/jquery/jqplot/jqplot.pyramidRenderer.js
+++ b/resources/jquery/jqplot/jqplot.pyramidRenderer.js
@@ -507,7 +507,7 @@
         }
     }
 
-    // Have to add hook here, becuase it needs called before series is inited.
+    // Have to add hook here, because it needs called before series is inited.
     $.jqplot.preInitHooks.push(preInit);
     
 


### PR DESCRIPTION
Reported at https://phabricator.wikimedia.org/T201491