### PR TITLE
Fixes "gallery" exposing file dimensions in captions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,7 @@ This is not a release yet.
 * Improved filtered format: More options, better test coverage, re-enabled by default (by Stephan Gambke)
 * #248 Fixed localization of numbers in the math result formats (by James Hong Kong)
 * [#365](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/365) Added support for the latest versions of the GraphViz extension
+* [#375](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/375) Fixed exposing of file dimensions in captions for the "gallery" format
 * Added support for installation together with the latest versions of the Maps extension (by Jeroen De Dauw)
 * Updated translations (by translatewiki.net community)
 

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -67,6 +67,11 @@ class Gallery extends ResultPrinter {
 
 		$ig->setShowBytes( false );
 		$ig->setShowFilename( false );
+		
+		if ( method_exists( $ig, 'setShowDimensions' ) ) {
+			$ig->setShowDimensions( false );
+		}
+		
 		$ig->setCaption( $this->mIntro ); // set caption to IQ header
 
 		// No need for a special page to use the parser but for the "normal" page


### PR DESCRIPTION
This PR is made in reference to: #375 

This PR addresses or contains:
- Fixes "gallery" exposing file dimensions in captions // Code as suggested in https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/375#issuecomment-367768383

This PR includes:
- [x] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #375 