### PR TITLE
Remove 'template arguments' parameter

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,9 +7,10 @@ This is not a release yet.
 * Raised minimum required version of PHP to 5.6
 * Raised minimum required version of MediaWiki to 1.27
 * Improved filtered format: More options, better test coverage, re-enabled by default (by Stephan Gambke)
-* #248 Fixed localization of numbers in the math result formats (by James Hong Kong)
+* [#248](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/248) Fixed localization of numbers in the math result formats (by James Hong Kong)
 * [#365](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/365) Added support for the latest versions of the GraphViz extension
 * [#375](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/375) Fixed exposing of file dimensions in captions for the "gallery" format
+* Tree format: Removed `template arguments` parameter
 * Added support for installation together with the latest versions of the Maps extension (by Jeroen De Dauw)
 * Updated translations (by translatewiki.net community)
 

--- a/formats/tree/TreeNodeVisitor.php
+++ b/formats/tree/TreeNodeVisitor.php
@@ -152,11 +152,9 @@ class TreeNodePrinter implements Visitor {
 
 			$label = $cell->getPrintRequest()->getLabel();
 
-			if ( $this->configuration['template arguments'] === 'numbered' || ( $label === '' ) ) {
+			if ( $this->configuration[ 'named args' ] === true || ( $label === '' ) ) {
 				$paramName = $columnNumber + 1;
-			} elseif ( $this->configuration['template arguments'] === 'legacy' ) {
-				$paramName = '?' . $label;
-			} else { // $this->configuration[ 'template arguments' ] === 'named'
+			} else {
 				$paramName = $label;
 			}
 

--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -73,20 +73,6 @@ class TreeResultPrinter extends ListResultPrinter {
 		// Don't support pagination in trees
 		$this->mSearchlabel = null;
 
-		if ( array_key_exists( 'template arguments', $this->params )
-			&& $this->params['template arguments'] !== 'numbered' ) {
-
-			if ( filter_var( $this->params['named args'], FILTER_VALIDATE_BOOLEAN ) === true ) {
-				$this->params['template arguments'] = 'legacy';
-			} elseif (
-				$this->params['template arguments'] !== 'named' &&
-				$this->params['template arguments'] !== 'legacy'
-			) {
-				// default
-				$this->params['template arguments'] = 'numbered';
-			}
-		}
-
 		// Allow "_" for encoding spaces, as documented
 		$this->params['sep'] = str_replace( '_', ' ', $this->params['sep'] );
 
@@ -177,6 +163,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @param $definitions array of IParamDefinition
 	 *
 	 * @return array of IParamDefinition|array
+	 * @throws Exception
 	 */
 	public function getParamDefinitions( array $definitions ) {
 		$params = parent::getParamDefinitions( $definitions );
@@ -290,11 +277,10 @@ class TreeResultPrinter extends ListResultPrinter {
 	private function initalizeStandardTemplateParameters() {
 
 		$query = $this->getQueryResult()->getQuery();
+		$userparam = trim( $this->params[ 'userparam' ] );
 
 		$this->standardTemplateParameters =
-			( trim( $this->params['userparam'] ) !== '' ? ( '|userparam=' . trim(
-					$this->params['userparam']
-				) ) : '' ) .
+			( $userparam !== '' ? ( '|userparam=' . $userparam ) : '' ) .
 			'|smw-resultquerycondition=' . $query->getQueryString() .
 			'|smw-resultquerylimit=' . $query->getLimit() .
 			'|smw-resultqueryoffset=' . $query->getOffset();
@@ -306,6 +292,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @param TreeNode[] $nodes
 	 *
 	 * @return TreeNode
+	 * @throws \Exception
 	 */
 	protected function buildTreeFromNodeList( $rootHash, $nodes ) {
 
@@ -362,7 +349,7 @@ class TreeResultPrinter extends ListResultPrinter {
 			'format' => trim( $this->params['format'] ),
 			'template' => trim( $this->params['template'] ),
 			'headers' => $this->params['headers'],
-			'template arguments' => $this->params['template arguments'],
+			'named args' => $this->params['named args'],
 			'sep' => $this->params['sep'],
 		];
 


### PR DESCRIPTION
This PR is made in reference to: #

The 'template arguments' parameter was introduced for compatibility and can be removed in SRF 3.0

This PR includes:
- [x] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed
