### PR TITLE
Update Gallery.php

### DIFF
--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -65,6 +65,11 @@ class Gallery extends ResultPrinter {
 	 */
 	public function getResultText( SMWQueryResult $results, $outputmode ) {
 
+		$numbers = $this->getNumbers( $results );
+				if ( count( $numbers ) == 0 ) {
+					return $this->params['default'];
+				}
+
 		$ig = new TraditionalImageGallery();
 
 		$ig->setShowBytes( false );
@@ -505,5 +510,20 @@ class Gallery extends ResultPrinter {
 		$title = $GLOBALS['wgTitle'];
 		return $title instanceof Title ? $title->getPageLanguage()->getNsText( NS_FILE ) : null;
 	}
-
+	/**
+	 * @param SMWQueryResult $res
+	 * 
+	 * @return float[]
+	 */
+	private function getNumbers( SMWQueryResult $res ) {
+		$numbers = [];
+		while ( $row = $res->getNext() ) {
+			foreach ( $row as $resultArray ) {
+				foreach ( $resultArray->getContent() as $dataItem ) {
+					self::addNumbersForDataItem( $dataItem, $numbers );
+				}
+			}
+		}
+		return $numbers;
+	}
 }


### PR DESCRIPTION
this should fix https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/396
gallery format now no longer ignores default= setting

This PR is made in reference to: #396 

This PR addresses or contains:
- new private function getNumbers
- call to function right after getResultText

Sorry for my unprofessional pull request :-)

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
