### PR TITLE
Add `template` to outline format, refs 88

### DIFF
--- a/src/Outline/README.md
+++ b/src/Outline/README.md
@@ -1,0 +1,53 @@
+# Outline format
+
+The format is to display pages in a hierarchical outline form, using one or more of the pages' properties as outline headers.
+
+## Usage
+
+```
+{{#ask: [[Category:Task]]
+ |?Severity
+ |format=outline
+ |outlineproperties=Severity, Assigned to
+ |template=phab-view
+}}
+```
+
+For example, with `phab-view` as template name, the `outline` format will generate two distinct templates `phab-view-header` and `phab-view-item` to be used for the output with `-header` and `-item` being a fixed affix to distinguish the output level of the result content.
+
+The `...-header` template will provide additional information and includes:
+- `#outlinelevel` the level of the header being processed (depends on the iteration level invoked by the `outlineproperties` parameter)
+- `#itemcount` provides a count information for the items assigned to the
+the level
+- `#userparam`
+
+The `...-item` template will also provide additional information such as:
+
+- `#itemsection` section number of the item
+- `#itemsubject` the subject (aka page) of the item processed
+- `#userparam` content provided by a user via the `#ask` `userparam` parameter
+
+
+## Examples
+
+Using a template can provide means to individually style the result output, for example a simple list can be turned into a phabricator task list.
+
+```
+{{#ask: [[Category:Task]]
+ ...
+ |outlineproperties=Severity
+ |template=phab-view
+}}
+```
+
+![image](https://user-images.githubusercontent.com/1245473/51059660-d2826b00-15e4-11e9-8ff3-bb1591b04e81.png)
+
+```
+{{#ask: [[Category:Task]]
+ ...
+ |outlineproperties=Severity, Assigned to
+ |template=phab-view
+}}
+```
+
+![image](https://user-images.githubusercontent.com/1245473/51059791-52103a00-15e5-11e9-85cf-86c503a10b55.png)

--- a/src/Outline/TemplateBuilder.php
+++ b/src/Outline/TemplateBuilder.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SRF\Outline;
+
+use SMW\Query\PrintRequest;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class TemplateBuilder {
+
+	/**
+	 * @var []
+	 */
+	private $params = [];
+
+	/**
+	 * @var Linker
+	 */
+	private $linker;
+
+	/**
+	 * @var string
+	 */
+	private $template = '';
+
+	/**
+	 * @param array $params
+	 */
+	public function __construct( array $params ) {
+		$this->params = $params;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Linker|null|false $linker
+	 */
+	public function setLinker( $linker ) {
+		$this->linker = $linker;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param OutlineTree $tree
+	 *
+	 * @return string
+	 */
+	public function build( $tree ) {
+		$this->tree( $tree );
+
+		return $this->template;
+	}
+
+	private function tree( $tree, $level = 0 ) {
+
+		if ( $tree->mUnsortedItems !== null ) {
+			foreach ( $tree->mUnsortedItems as $i => $item ) {
+				$this->template .= $this->item( $i, $item );
+			}
+		}
+
+		foreach ( $tree->mTree as $key => $node ) {
+			$property = $this->params['outlineproperties'][$level];
+			$class = $this->params['template'] . '-section-' . strtolower( str_replace( ' ', '-', $property ) );
+
+			$this->template .= "<div class='$class'>";
+			$this->template .= $this->open( $this->params['template'] . "-header" );
+			$this->template .= $this->parameter( $property, $key );
+			$this->template .= $this->parameter( "#outlinelevel", $level );
+			$this->template .= $this->parameter( "#itemcount",  $node->leafCount );
+			$this->template .= $this->parameter( "#userparam", $this->params['userparam'] );
+			$this->template .= $this->close();
+			$this->template .= "<div class='" . $this->params['template'] . "-items'>";
+			$this->tree( $node, $level + 1 );
+			$this->template .= "</div>";
+			$this->template .= "</div>";
+		}
+	}
+
+	private function item( $i, $item ) {
+
+		$first_col = true;
+		$template = '';
+		$linker = $this->params['link'] === 'all' ? $this->linker : null;
+		$itemnumber = 0;
+
+		foreach ( $item->mRow as $resultArray ) {
+
+			$printRequest = $resultArray->getPrintRequest();
+			$val = $printRequest->getText( SMW_OUTPUT_WIKI, null );
+
+			if ( in_array( $val, $this->params['outlineproperties'] ) ) {
+				continue;
+			}
+
+			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
+				$template .= $this->open( $this->params['template'] . '-item' );
+				$template .= $this->parameter( "#itemsection", $i );
+
+				$template .= $this->parameter( "#itemnumber", $itemnumber );
+				$template .= $this->parameter( "#userparam", $this->params['userparam'] );
+
+				$template .= $this->itemText( $dv, $linker, $printRequest, $first_col );
+				$template .= $this->close();
+
+				$itemnumber++;
+			}
+		}
+
+		return "<div class='" . $this->params['template'] . "-item'>" . $template . '</div>';
+	}
+
+	private function itemText( $dv, $linker, $printRequest, &$first_col ) {
+
+		if ( $first_col && $printRequest->isMode( PrintRequest::PRINT_THIS ) ) {
+			$first_col = false;
+
+			if ( $linker === null && ( $caption = $dv->getDisplayTitle() ) !== '' ) {
+				$dv->setCaption( $caption );
+			}
+
+			$text = $dv->getShortText(
+				SMW_OUTPUT_WIKI,
+				$this->params['link'] === 'subject' ? $this->linker : $linker
+			);
+
+			return $this->parameter( "#itemsubject", $text );
+		}
+
+		$text = $dv->getShortText(
+			SMW_OUTPUT_WIKI,
+			$linker
+		);
+
+		return $this->parameter( $printRequest->getLabel(), $text );
+	}
+
+	private function open( $v ) {
+		return "{{" . $v;
+	}
+
+	private function parameter( $k, $v ) {
+		return " |$k=$v";
+	}
+
+	private function close() {
+		return "}}";
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/outline-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/outline-01.json
@@ -1,0 +1,101 @@
+{
+	"description": "Test `format=outline` template output",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Assigned to",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Severity",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "outline-test-header",
+			"contents": "<includeonly> #outlinelevel: {{{#outlinelevel}}}, #itemcount: {{{#itemcount}}}, Severity: {{{Severity}}}</includeonly>"
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "outline-test-item",
+			"contents": "<includeonly> #itemsubject: {{{#itemsubject}}}, #itemsection: {{{#itemsection}}}, #itemnumber: {{{#itemnumber}}}, Assigned to: {{{Assigned to}}}</includeonly>"
+		},
+		{
+			"page": "SRF/Outline/1",
+			"contents": "[[Assigned to::John]] [[Severity::Normal]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/2",
+			"contents": "[[Assigned to::Jane]] [[Severity::Urgent]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/3",
+			"contents": "[[Assigned to::田中]] [[Severity::Urgent]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/Q.1",
+			"contents": "{{#ask: [[Category:Outline]] |?Severity |?Assigned to |format=outline |template=outline-test |sort=Severity,Assigned to |outlineproperties=Severity |link=none }}"
+		},
+		{
+			"page": "SRF/Outline/Q.2",
+			"contents": "{{#ask: [[Category:Outline]] |?Severity |?Assigned to |format=outline |template=outline-test |sort=Severity,Assigned to |outlineproperties=Severity,Assigned to |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (`outlineproperties=Severity`)",
+			"subject": "SRF/Outline/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"outline-test-section-severity\"> #outlinelevel: 0, #itemcount: 1, Severity: Normal",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-item\">",
+					"#itemsubject: SRF/Outline/1, #itemsection: 0, #itemnumber: 0, Assigned to: {{{Assigned to}}}",
+					"#itemsubject: {{{#itemsubject}}}, #itemsection: 0, #itemnumber: 1, Assigned to: John</div></div></div>",
+					"<div class=\"outline-test-section-severity\"> #outlinelevel: 0, #itemcount: 2, Severity: Urgent",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-item\">",
+					"#itemsubject: SRF/Outline/2, #itemsection: 0, #itemnumber: 0, Assigned to: {{{Assigned to}}}",
+					"#itemsubject: {{{#itemsubject}}}, #itemsection: 0, #itemnumber: 1, Assigned to: Jane</div>",
+					"#itemsubject: SRF/Outline/3, #itemsection: 1, #itemnumber: 0, Assigned to: {{{Assigned to}}}",
+					"#itemsubject: {{{#itemsubject}}}, #itemsection: 1, #itemnumber: 1, Assigned to: 田中</div></div></div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (`outlineproperties=Severity,Assigned to`)",
+			"subject": "SRF/Outline/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"outline-test-section-severity\"> #outlinelevel: 0, #itemcount: 1, Severity: Normal",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-section-assigned-to\">",
+					"#outlinelevel: 1, #itemcount: 1, Severity: {{{Severity}}}",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-item\">",
+					"#itemsubject: SRF/Outline/1, #itemsection: 0, #itemnumber: 0, Assigned to: {{{Assigned to}}}</div></div></div></div></div>",
+					"<div class=\"outline-test-section-severity\"> #outlinelevel: 0, #itemcount: 2, Severity: Urgent",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-section-assigned-to\">",
+					"#outlinelevel: 1, #itemcount: 1, Severity: {{{Severity}}}",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-item\">",
+					"#itemsubject: SRF/Outline/2, #itemsection: 0, #itemnumber: 0, Assigned to: {{{Assigned to}}}</div></div></div>",
+					"<div class=\"outline-test-section-assigned-to\"> #outlinelevel: 1, #itemcount: 1, Severity: {{{Severity}}}",
+					"<div class=\"outline-test-items\"><div class=\"outline-test-item\">",
+					"#itemsubject: SRF/Outline/3, #itemsection: 0, #itemnumber: 0, Assigned to: {{{Assigned to}}}</div></div></div></div></div>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SRF\Tests\Outline;
+
+use SRF\Outline\TemplateBuilder;
+
+/**
+ * @covers \SRF\Outline\TemplateBuilder
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class TemplateBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			TemplateBuilder::class,
+			new TemplateBuilder( [] )
+		);
+	}
+
+	public function tesBuild() {
+
+		$params = [
+			'outlineproperties' => [ 'Foo' ],
+			'template' => 'Bar',
+			'userparam' => ''
+		];
+
+		$instance = new TemplateBuilder( $params );
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #88 

This PR addresses or contains:

- Adds the `template` parameter and `TemplateBuilder` to create individual hierarchical output lists using a template
- `named args` are `true` by default and I haven't considered implementing numerical parameter (aka `{{{1}}}`) support in the `TemplateBuilder` (which means it is missing by design and if required someone should send a patch and test)
- Adds `outline-01.json` integration test to verify that the `template` produces a specified output
- The format hasn't seen any updates in years and this PR fixes a notorious "Notice: Array to string conversion in .../w/extensions/SemanticMediaWiki/includes/SMW_Infolink.php on line 469" caused by the wrong use of `$link = $res->getQueryLink(); / $link->setParameter( $this->params['outlineproperties'], 'outlineproperties' );`


This PR includes:

- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #88 

## Example

Using the `template` output allows to create lists like the phabricator task list (To create that output was the reason I took an interest in this format in the first place.).

![image](https://user-images.githubusercontent.com/1245473/51067428-1471d800-160a-11e9-91b7-be19dadc87be.png)

