### PR TITLE
Tidy (Outline format), refs 457

### DIFF
--- a/src/Outline/ListTreeBuilder.php
+++ b/src/Outline/ListTreeBuilder.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace SRF\Outline;
+
+use SMW\Query\PrintRequest;
+use SRF\Outline\OutlineTree;
+use SMWDataItem as DataItem;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ListTreeBuilder {
+
+	/**
+	 * @var []
+	 */
+	private $params = [];
+
+	/**
+	 * @var Linker
+	 */
+	private $linker;
+
+	/**
+	 * @param array $params
+	 */
+	public function __construct( array $params ) {
+		$this->params = $params;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param Linker|null|false $linker
+	 */
+	public function setLinker( $linker ) {
+		$this->linker = $linker;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param OutlineTree $tree
+	 *
+	 * @return string
+	 */
+	public function build( OutlineTree $outlineTree ) {
+		return $this->tree( $outlineTree );
+	}
+
+	private function tree( $outline_tree, $level = 0 ) {
+		$text = "";
+
+		if ( !is_null( $outline_tree->items ) ) {
+			$text .= "<ul>\n";
+			foreach ( $outline_tree->items as $item ) {
+				$text .= "<li>{$this->item($item)}</li>\n";
+			}
+			$text .= "</ul>\n";
+		}
+
+		if ( $level > 0 ) {
+			$text .= "<ul>\n";
+		}
+
+		$num_levels = count( $this->params['outlineproperties'] );
+		// set font size and weight depending on level we're at
+		$font_level = $level;
+
+		if ( $num_levels < 4 ) {
+			$font_level += ( 4 - $num_levels );
+		}
+
+		if ( $font_level == 0 ) {
+			$font_size = 'x-large';
+		} elseif ( $font_level == 1 ) {
+			$font_size = 'large';
+		} elseif ( $font_level == 2 ) {
+			$font_size = 'medium';
+		} else {
+			$font_size = 'small';
+		}
+
+		if ( $font_level == 3 ) {
+			$font_weight = 'bold';
+		} else {
+			$font_weight = 'regular';
+		}
+
+		foreach ( $outline_tree->tree as $key => $node ) {
+			$text .= "<p style=\"font-size: $font_size; font-weight: $font_weight;\">$key</p>\n";
+			$text .= $this->tree( $node, $level + 1 );
+		}
+
+		if ( $level > 0 ) {
+			$text .= "</ul>\n";
+		}
+
+		return $text;
+	}
+
+	private function item( $item ) {
+		$first_col = true;
+		$found_values = false; // has anything but the first column been printed?
+		$result = "";
+
+		foreach ( $item->row as $resultArray ) {
+
+			$printRequest = $resultArray->getPrintRequest();
+			$val = $printRequest->getText( SMW_OUTPUT_WIKI, null );
+			$first_value = true;
+
+			if ( in_array( $val, $this->params['outlineproperties'] ) ) {
+				continue;
+			}
+
+			$linker = $this->params['link'] === 'all' ? $this->linker : null;
+
+			if ( $this->params['link'] === 'subject' && $printRequest->isMode( PrintRequest::PRINT_THIS ) ) {
+				$linker = $this->linker;
+			}
+
+			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
+
+				if ( !$first_col && !$found_values ) { // first values after first column
+					$result .= ' (';
+					$found_values = true;
+				} elseif ( $found_values || !$first_value ) {
+					// any value after '(' or non-first values on first column
+					$result .= ', ';
+				}
+
+				if ( $first_value ) { // first value in any column, print header
+					$first_value = false;
+					if ( $this->params['showHeaders'] && ( '' != $printRequest->getLabel() ) ) {
+						$result .= $printRequest->getText( SMW_OUTPUT_WIKI, $linker ) . ' ';
+					}
+				}
+
+				$dataItem = $dv->getDataItem();
+
+				if ( $linker === null && $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE && ( $caption = $dv->getDisplayTitle() ) !== '' ) {
+					$dv->setCaption( $caption );
+				}
+
+				$result .= $dv->getShortText( SMW_OUTPUT_WIKI, $linker );
+			}
+
+			$first_col = false;
+		}
+
+		if ( $found_values ) {
+			$result .= ')';
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Outline/OutlineItem.php
+++ b/src/Outline/OutlineItem.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SRF\Outline;
+
+/**
+ * Represents a single item, or page, in the outline - contains both the
+ * SMWResultArray and an array of some of its values, for easier aggregation
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ */
+class OutlineItem {
+
+	/**
+	 * @var [type]
+	 */
+	public $row;
+
+	/**
+	 * @var []
+	 */
+	private $vals;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $row
+	 */
+	public function __construct( $row ) {
+		$this->row = $row;
+		$this->vals = [];
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $name
+	 * @param $value
+	 */
+	public function addFieldValue( $key, $value ) {
+		if ( array_key_exists( $key, $this->vals ) ) {
+			$this->vals[$key][] = $value;
+		} else {
+			$this->vals[$key] = [ $value ];
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $row
+	 */
+	public function getFieldValues( $key ) {
+
+		if ( array_key_exists( $key, $this->vals ) ) {
+			return $this->vals[$key];
+		}
+
+		return [ wfMessage( 'srf_outline_novalue' )->text() ];
+	}
+
+}

--- a/src/Outline/OutlineTree.php
+++ b/src/Outline/OutlineTree.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SRF\Outline;
+
+/**
+ * A tree structure for holding the outline data
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ */
+class OutlineTree {
+
+	/**
+	 * @var []
+	 */
+	public $tree;
+
+	/**
+	 * @var []
+	 */
+	public $items;
+
+	/**
+	 * @var integer
+	 */
+	public $itemCount = 0;
+
+	/**
+	 * @var integer
+	 */
+	public $leafCount = 0;
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param array $items
+	 */
+	public function __construct( $items = [] ) {
+		$this->tree = [];
+		$this->items = $items;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $item
+	 */
+	public function addItem( $item ) {
+		$this->items[] = $item;
+		$this->itemCount++;
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $vals
+	 * @param $item
+	 */
+	public function categorizeItem( $vals, $item ) {
+		foreach ( $vals as $val ) {
+			if ( array_key_exists( $val, $this->tree ) ) {
+				$this->tree[$val]->items[] = $item;
+				$this->tree[$val]->leafCount++;
+			} else {
+				$this->tree[$val] = new self( [ $item ] );
+				$this->tree[$val]->leafCount++;
+			}
+		}
+	}
+
+	/**
+	 * @since 3.1
+	 *
+	 * @param $property
+	 */
+	public function addProperty( $property ) {
+		if ( count( $this->items ) > 0 ) {
+			foreach ( $this->items as $item ) {
+				$cur_vals = $item->getFieldValues( $property );
+				$this->categorizeItem( $cur_vals, $item );
+			}
+			$this->items = null;
+		} else {
+			foreach ( $this->tree as $i => $node ) {
+				$this->tree[$i]->addProperty( $property );
+			}
+		}
+	}
+
+}

--- a/src/Outline/TemplateBuilder.php
+++ b/src/Outline/TemplateBuilder.php
@@ -3,6 +3,7 @@
 namespace SRF\Outline;
 
 use SMW\Query\PrintRequest;
+use SRF\Outline\OutlineTree;
 
 /**
  * @license GNU GPL v2+
@@ -50,21 +51,21 @@ class TemplateBuilder {
 	 *
 	 * @return string
 	 */
-	public function build( $tree ) {
-		$this->tree( $tree );
+	public function build( OutlineTree $outlineTree ) {
+		$this->tree( $outlineTree );
 
 		return $this->template;
 	}
 
-	private function tree( $tree, $level = 0 ) {
+	private function tree( $outlineTree, $level = 0 ) {
 
-		if ( $tree->mUnsortedItems !== null ) {
-			foreach ( $tree->mUnsortedItems as $i => $item ) {
+		if ( $outlineTree->items !== null ) {
+			foreach ( $outlineTree->items as $i => $item ) {
 				$this->template .= $this->item( $i, $item );
 			}
 		}
 
-		foreach ( $tree->mTree as $key => $node ) {
+		foreach ( $outlineTree->tree as $key => $node ) {
 			$property = $this->params['outlineproperties'][$level];
 			$class = $this->params['template'] . '-section-' . strtolower( str_replace( ' ', '-', $property ) );
 
@@ -89,7 +90,7 @@ class TemplateBuilder {
 		$linker = $this->params['link'] === 'all' ? $this->linker : null;
 		$itemnumber = 0;
 
-		foreach ( $item->mRow as $resultArray ) {
+		foreach ( $item->row as $resultArray ) {
 
 			$printRequest = $resultArray->getPrintRequest();
 			$val = $printRequest->getText( SMW_OUTPUT_WIKI, null );

--- a/tests/phpunit/Integration/JSONScript/TestCases/outline-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/outline-02.json
@@ -1,0 +1,105 @@
+{
+	"description": "Test `format=outline` list output",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Assigned to",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Severity",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "SRF/Outline/1",
+			"contents": "[[Assigned to::John]] [[Severity::Normal]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/2",
+			"contents": "[[Assigned to::Jane]] [[Severity::Urgent]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/3",
+			"contents": "[[Assigned to::田中]] [[Severity::Urgent]] [[Category:Outline]]"
+		},
+		{
+			"page": "SRF/Outline/Q.1",
+			"contents": "{{#ask: [[Category:Outline]] |?Severity |?Assigned to |format=outline |sort=Severity,Assigned to |outlineproperties=Severity |link=none }}"
+		},
+		{
+			"page": "SRF/Outline/Q.2",
+			"contents": "{{#ask: [[Category:Outline]] |?Severity |?Assigned to |format=outline |sort=Severity,Assigned to |outlineproperties=Severity,Assigned to |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (`outlineproperties=Severity`)",
+			"subject": "SRF/Outline/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"<p style=\"font-size: small; font-weight: bold;\">Normal</p>",
+					"<ul>",
+					"<li>SRF/Outline/1 (Assigned to John)</li>",
+					"</ul>",
+					"<ul>",
+					"</ul>",
+					"<p style=\"font-size: small; font-weight: bold;\">Urgent</p>",
+					"<ul>",
+					"<li>SRF/Outline/2 (Assigned to Jane)</li>",
+					"<li>SRF/Outline/3 (Assigned to 田中)</li>",
+					"</ul>",
+					"<ul>",
+					"</ul>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 (`outlineproperties=Severity,Assigned to`)",
+			"subject": "SRF/Outline/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<p style=\"font-size: medium; font-weight: regular;\">Normal</p>",
+					"<ul>",
+					"<p style=\"font-size: small; font-weight: bold;\">John</p>",
+					"<ul>",
+					"<li>SRF/Outline/1</li>",
+					"</ul>",
+					"<ul>",
+					"</ul>",
+					"</ul>",
+					"<p style=\"font-size: medium; font-weight: regular;\">Urgent</p>",
+					"<ul>",
+					"<p style=\"font-size: small; font-weight: bold;\">Jane</p>",
+					"<ul>",
+					"<li>SRF/Outline/2</li>",
+					"</ul>",
+					"<ul>",
+					"</ul>",
+					"<p style=\"font-size: small; font-weight: bold;\">田中</p>",
+					"<ul>",
+					"<li>SRF/Outline/3</li>",
+					"</ul>",
+					"<ul>",
+					"</ul>",
+					"</ul>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
@@ -2,11 +2,11 @@
 
 namespace SRF\Tests\Outline;
 
-use SRF\Outline\TemplateBuilder;
+use SRF\Outline\ListTreeBuilder;
 use SRF\Outline\OutlineTree;
 
 /**
- * @covers \SRF\Outline\TemplateBuilder
+ * @covers \SRF\Outline\ListTreeBuilder
  * @group semantic-result-formats
  *
  * @license GNU GPL v2+
@@ -14,25 +14,23 @@ use SRF\Outline\OutlineTree;
  *
  * @author mwjames
  */
-class TemplateBuilderTest extends \PHPUnit_Framework_TestCase {
+class ListTreeBuilderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			TemplateBuilder::class,
-			new TemplateBuilder( [] )
+			ListTreeBuilder::class,
+			new ListTreeBuilder( [] )
 		);
 	}
 
 	public function testBuildForEmptyTree() {
 
 		$params = [
-			'outlineproperties' => [ 'Foo' ],
-			'template' => 'Bar',
-			'userparam' => ''
+			'outlineproperties' => [ 'Foo' ]
 		];
 
-		$instance = new TemplateBuilder( $params );
+		$instance = new ListTreeBuilder( $params );
 
 		$this->assertInternalType(
 			'string',

--- a/tests/phpunit/Unit/Outline/OutlineItemTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineItemTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SRF\Tests\Outline;
+
+use SRF\Outline\OutlineItem;
+
+/**
+ * @covers \SRF\Outline\OutlineItem
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class OutlineItemTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			OutlineItem::class,
+			new OutlineItem( [] )
+		);
+	}
+
+	public function testPropertyAccess() {
+
+		$instance = new OutlineItem( [ 'Foo' ] );
+
+		$this->assertEquals(
+			[ 'Foo' ],
+			$instance->row
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/Outline/OutlineTreeTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineTreeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SRF\Tests\Outline;
+
+use SRF\Outline\OutlineTree;
+
+/**
+ * @covers \SRF\Outline\OutlineTree
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class OutlineTreeTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			OutlineTree::class,
+			new OutlineTree( [] )
+		);
+	}
+
+	public function testPropertyAccess() {
+
+		$instance = new OutlineTree();
+
+		$this->assertEmpty(
+			$instance->tree
+		);
+
+		$this->assertEmpty(
+			$instance->items
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->itemCount
+		);
+
+		$this->assertEquals(
+			0,
+			$instance->leafCount
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #457

This PR addresses or contains:

- Just some clean-ups some issues I found while working on #457
  - Moves `SRFOutlineItem` (part of `SRF_Outline.php`) to `OutlineItem` + rudimentary test
  - Moves `SRFOutlineTree` (part of `SRF_Outline.php`) to `OutlineTree` + a rudimentary test
  - Moves tree building code to `ListTreeBuilder` + rudimentary test
- Adds `outline-02.json` integration test to validate the list ouput
- Fixes `link=...` which wasn't working at all

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #
