### PR TITLE
ListWidget: Remove usage of `$this->mFormat` (not taken into account anymore by parent class)

### DIFF
--- a/formats/widget/SRF_ListWidget.php
+++ b/formats/widget/SRF_ListWidget.php
@@ -1,6 +1,7 @@
 <?php
 
-use SMW\ListResultPrinter;
+use SMW\Query\ResultPrinters\ListResultPrinter\ListResultBuilder;
+use SMW\Query\ResultPrinters\ResultPrinter;
 
 /**
  * Extends the list result printer (SMW_QP_List.php) with a JavaScript
@@ -13,7 +14,7 @@ use SMW\ListResultPrinter;
  * @ingroup SemanticResultFormats
  * @file SRF_ListWidget.php
  */
-class SRFListWidget extends ListResultPrinter {
+class SRFListWidget extends ResultPrinter {
 
 	/**
 	 * Get a human readable label for this printer.
@@ -38,11 +39,20 @@ class SRFListWidget extends ListResultPrinter {
 		static $statNr = 0;
 		//$this->isHTML = true;
 
-		// Set output type for the parent
-		$this->params['format'] = $this->params['listtype'] == 'ordered' || $this->params['listtype'] == 'ol' ? 'ol' : 'ul';
+		$listType = $this->params[ 'listtype' ] === 'ordered' || $this->params[ 'listtype' ] === 'ol' ? 'ol' : 'ul';
+
+		$builder = new ListResultBuilder( $res, $this->mLinker );
+
+		$builder->set( $this->params );
+		$builder->set( [
+			'format' => $listType,
+			'link-first' => $this->mLinkFirst,
+			'link-others' => $this->mLinkOthers,
+			'show-headers' => $this->mShowHeaders,
+		] );
 
 		// Get results from SMWListResultPrinter
-		$result = parent::getResultText( $res, $outputmode );
+		$result = $builder->getResultText();
 
 		// Count widgets
 		$listwidgetID = 'listwidget-' . ++$statNr;
@@ -70,7 +80,7 @@ class SRFListWidget extends ListResultPrinter {
 			'div',
 			[
 				'class' => 'srf-listwidget ' . htmlspecialchars( $this->params['class'] ),
-				'data-listtype' => $this->params['format'],
+				'data-listtype' => $listType,
 				'data-widget' => $this->params['widget'],
 				'data-pageitems' => $this->params['pageitems'],
 			],

--- a/formats/widget/SRF_ListWidget.php
+++ b/formats/widget/SRF_ListWidget.php
@@ -39,7 +39,7 @@ class SRFListWidget extends ListResultPrinter {
 		//$this->isHTML = true;
 
 		// Set output type for the parent
-		$this->mFormat = $this->params['listtype'] == 'ordered' || $this->params['listtype'] == 'ol' ? 'ol' : 'ul';
+		$this->params['format'] = $this->params['listtype'] == 'ordered' || $this->params['listtype'] == 'ol' ? 'ol' : 'ul';
 
 		// Get results from SMWListResultPrinter
 		$result = parent::getResultText( $res, $outputmode );
@@ -70,7 +70,7 @@ class SRFListWidget extends ListResultPrinter {
 			'div',
 			[
 				'class' => 'srf-listwidget ' . htmlspecialchars( $this->params['class'] ),
-				'data-listtype' => $this->mFormat,
+				'data-listtype' => $this->params['format'],
 				'data-widget' => $this->params['widget'],
 				'data-pageitems' => $this->params['pageitems'],
 			],

--- a/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
@@ -49,7 +49,7 @@
 	],
 	"tests": [
 		{
-			"type": "parser-html",
+			"type": "parser",
 			"about": "#0 Listwidget - alphabet - unordered",
 			"subject": "Listwidget - alphabet - unordered",
 			"assert-output": {
@@ -62,7 +62,7 @@
 			}
 		},
 		{
-			"type": "parser-html",
+			"type": "parser",
 			"about": "#1 Listwidget - menu - unordered",
 			"subject": "Listwidget - menu - unordered",
 			"assert-output": {
@@ -74,7 +74,7 @@
 			}
 		},
 		{
-			"type": "parser-html",
+			"type": "parser",
 			"about": "#2 Listwidget - pagination - unordered",
 			"subject": "Listwidget - pagination - unordered",
 			"assert-output": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
@@ -36,53 +36,45 @@
 		},
 		{
 			"page": "Listwidget - alphabet - unordered",
-			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=alphabet |sep= }}"
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=alphabet |pageitems=6}}"
 		},
 		{
-			"page": "Listwidget - menu - unordered",
-			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=menu |sep= }}"
+			"page": "Listwidget - menu - listtype unspecified",
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |widget=menu }}"
 		},
 		{
-			"page": "Listwidget - pagination - unordered",
-			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=pagination |sep= }}"
+			"page": "Listwidget - pagination - ordered",
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=ordered |widget=pagination }}"
 		}
 	],
 	"tests": [
 		{
-			"type": "parser",
+			"type": "parser-html",
 			"about": "#0 Listwidget - alphabet - unordered",
 			"subject": "Listwidget - alphabet - unordered",
 			"assert-output": {
 				"to-contain": [
-					"<a class=\"_ ln-disabled\" href=\"#\">0-9</a>",
-					"<a class=\"m ln-selected\" href=\"#\">M</a>",
-					"<ul class=\"alphabet-container\" id=\"listwidget-6\">",
-					"<li class=\"smw-row ln-m\" style=\"\"><span class=\"smw-field\"><span class=\"smw-value\"><a href=\"/May 2006\" data-hasqtip=\"7\" oldtitle=\"May 2006\" title=\"\">May 2006</a></span></span></li>"
+					".srf-listwidget[data-listtype=\"ul\"][data-widget=\"alphabet\"][data-pageitems=\"6\"] .listwidget-container[id]"
 				]
 			}
 		},
 		{
-			"type": "parser",
-			"about": "#1 Listwidget - menu - unordered",
-			"subject": "Listwidget - menu - unordered",
+			"type": "parser-html",
+			"about": "#1 Listwidget - menu - listtype unspecified",
+			"subject": "Listwidget - menu - listtype unspecified",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"lm-letters\"><a class=\"_ lm-disabled\" href=\"#\">0-9</a>",
-					"<a class=\"l lm-disabled\" href=\"#\">L</a><a class=\"m\" href=\"#\">M</a>",
-					"<div class=\"lm-menu\" style=\"width: 1649px; display: none;\">"
+					".srf-listwidget[data-listtype=\"ul\"][data-widget=\"menu\"][data-pageitems=\"5\"] .listwidget-container[id]"
 				]
 			}
 		},
 		{
-			"type": "parser",
-			"about": "#2 Listwidget - pagination - unordered",
-			"subject": "Listwidget - pagination - unordered",
+			"type": "parser-html",
+			"about": "#2 Listwidget - pagination - ordered",
+			"subject": "Listwidget - pagination - ordered",
 			"assert-output": {
 				"to-contain": [
-					"<a class=\"first_link no_more\" href=\"\">First</a>",
-					"<a class=\"page_link first active_page\" href=\"\" longdesc=\"0\" style=\"\">1</a>",
-					"<ul class=\"pagination-container\" id=\"listwidget-2\">",
-					"<li class=\"smw-row\" style=\"\"><span class=\"smw-field\"><span class=\"smw-value\"><a href=\"/May 2000\" data-hasqtip=\"2\" oldtitle=\"May 2000\" title=\"\">May 2000</a>"
+					".srf-listwidget[data-listtype=\"ol\"][data-widget=\"pagination\"][data-pageitems=\"5\"] .listwidget-container[id]"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/listwidget-01.json
@@ -1,0 +1,103 @@
+{
+	"description": "Listwidget format: widgets - unordered (#449 - `wgContLang=fr`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "Listwidget example",
+			"contents": "Holds listwidget examples."
+		},
+		{
+			"page": "May 2000",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2001",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2002",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2003",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2004",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2005",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "May 2006",
+			"contents": "[[Category:Listwidget example]]"
+		},
+		{
+			"page": "Listwidget - alphabet - unordered",
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=alphabet |sep= }}"
+		},
+		{
+			"page": "Listwidget - menu - unordered",
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=menu |sep= }}"
+		},
+		{
+			"page": "Listwidget - pagination - unordered",
+			"contents": "{{#ask: [[Category:Listwidget example]] |format=listwidget |link=all |headers=show |listtype=unordered |widget=pagination |sep= }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser-html",
+			"about": "#0 Listwidget - alphabet - unordered",
+			"subject": "Listwidget - alphabet - unordered",
+			"assert-output": {
+				"to-contain": [
+					"<a class=\"_ ln-disabled\" href=\"#\">0-9</a>",
+					"<a class=\"m ln-selected\" href=\"#\">M</a>",
+					"<ul class=\"alphabet-container\" id=\"listwidget-6\">",
+					"<li class=\"smw-row ln-m\" style=\"\"><span class=\"smw-field\"><span class=\"smw-value\"><a href=\"/May 2006\" data-hasqtip=\"7\" oldtitle=\"May 2006\" title=\"\">May 2006</a></span></span></li>"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "#1 Listwidget - menu - unordered",
+			"subject": "Listwidget - menu - unordered",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"lm-letters\"><a class=\"_ lm-disabled\" href=\"#\">0-9</a>",
+					"<a class=\"l lm-disabled\" href=\"#\">L</a><a class=\"m\" href=\"#\">M</a>",
+					"<div class=\"lm-menu\" style=\"width: 1649px; display: none;\">"
+				]
+			}
+		},
+		{
+			"type": "parser-html",
+			"about": "#2 Listwidget - pagination - unordered",
+			"subject": "Listwidget - pagination - unordered",
+			"assert-output": {
+				"to-contain": [
+					"<a class=\"first_link no_more\" href=\"\">First</a>",
+					"<a class=\"page_link first active_page\" href=\"\" longdesc=\"0\" style=\"\">1</a>",
+					"<ul class=\"pagination-container\" id=\"listwidget-2\">",
+					"<li class=\"smw-row\" style=\"\"><span class=\"smw-field\"><span class=\"smw-value\"><a href=\"/May 2000\" data-hasqtip=\"2\" oldtitle=\"May 2000\" title=\"\">May 2000</a>"
+				]
+			}
+		}
+
+	],
+	"settings": {
+		"wgContLang": "fr",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": true
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #449 

This PR addresses or contains:
- Remove internal interface `mFormat` that does not exist anymore

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #449
