### PR TITLE
Re-enable master as voting test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,14 @@ matrix:
       php: 7.1
     - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev; TYPE=coverage
       php: 7.0
-    - env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
+	- env: DB=sqlite; MW=1.31.1; SMW=~3.0
+	  php: 7.0
+	- env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
       php: 7.0
     - env: DB=mysql; MW=1.27.3; SMW=~3.0@dev
       php: 5.6
     - env: DB=postgres; MW=1.27.3; SMW=~3.0@dev
       php: 5.6
-  allow_failures:
-    # Broken due to https://phabricator.wikimedia.org/T188840
-    - env: DB=mysql; MW=master; SMW=~3.0@dev
 
 install:
   - bash ./build/travis/install-mediawiki.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
       php: 7.1
     - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev; TYPE=coverage
       php: 7.0
-	- env: DB=sqlite; MW=1.31.1; SMW=~3.0
-	  php: 7.0
-	- env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
+    - env: DB=sqlite; MW=1.31.1; SMW=~3.0
+      php: 7.0
+    - env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
       php: 7.0
     - env: DB=mysql; MW=1.27.3; SMW=~3.0@dev
       php: 5.6


### PR DESCRIPTION
This PR is made in reference to: #467

This PR addresses or contains:
- Re-enable master as voting setup in CI tests

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
