### PR TITLE
Revert "Re-enable master as voting test setup"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,15 @@ matrix:
       php: 7.1
     - env: DB=mysql; MW=1.28.2; SMW=~3.0@dev; TYPE=coverage
       php: 7.0
-    - env: DB=sqlite; MW=1.31.1; SMW=~3.0
-      php: 7.0
     - env: DB=sqlite; MW=1.28.2; SMW=~3.0@dev
       php: 7.0
     - env: DB=mysql; MW=1.27.3; SMW=~3.0@dev
       php: 5.6
     - env: DB=postgres; MW=1.27.3; SMW=~3.0@dev
       php: 5.6
+  allow_failures:
+    # Broken due to https://phabricator.wikimedia.org/T188840
+    - env: DB=mysql; MW=master; SMW=~3.0@dev
 
 install:
   - bash ./build/travis/install-mediawiki.sh


### PR DESCRIPTION
Reverts SemanticMediaWiki/SemanticResultFormats#484

This just invites trouble has seen by https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3914, https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3915, https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3916 and I don't have the time deal with this any time soon.