### PR TITLE
Timeseries format: Only correct plot height when there are tabs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,9 @@
 These are the release notes for the [Semantic Result Formats](https://www.semantic-mediawiki.org/wiki/Extension:Semantic_Result_Formats) (a.k.a SRF) MediaWiki extension.
 
+## SRF 3.0.2
+
+* [#400](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/391) Fix Timeseries format: `uncaught exception: Invalid dimensions for plot` (by Christian Zagrodnick)
+
 ## SRF 3.0.1
 
 Released on March 27, 2019.

--- a/formats/timeseries/resources/ext.srf.timeseries.flot.js
+++ b/formats/timeseries/resources/ext.srf.timeseries.flot.js
@@ -135,7 +135,10 @@
 			// Tabs height can vary (due to CSS) therefore after tabs instance was
 			// created get the height
 			var _tabs = chart.find( '.ui-tabs-nav' );
-			container.find( '.' + plotClass ).css( { 'height': height - _tabs.outerHeight() , 'width': width } );
+			if (_tabs.length > 0) {
+				height -= _tabs.outerHeight();
+			}
+			container.find( '.' + plotClass ).css( { 'height': height, 'width': width } );
 
 			// Draw chart
 			container.srfFlotTimeSeries( 'chart', settings );


### PR DESCRIPTION
This PR is made in reference to: #400 

This PR addresses or contains:
- Fix Timeseries format: `uncaught exception: Invalid dimensions for plot` 

This PR includes:
- [X] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #400 