### PR TITLE
Add `nodelabel` parameter with `displaytitle` option

### DIFF
--- a/formats/graphviz/SRF_Graph.php
+++ b/formats/graphviz/SRF_Graph.php
@@ -15,6 +15,12 @@
  */
 class SRFGraph extends SMWResultPrinter {
 
+	const NODELABEL_DISPLAYTITLE = 'displaytitle';
+
+	public static $NODE_LABELS = [
+		self::NODELABEL_DISPLAYTITLE,
+	];
+
 	public static $NODE_SHAPES = [
 		'box',
 		'box3d',
@@ -219,7 +225,7 @@ class SRFGraph extends SMWResultPrinter {
 
 		$text = $this->getWordWrappedText( $text, $this->m_wordWrapLimit );
 
-		if ( $this->m_nodeLabel === 'displaytitle' && $object instanceof SMWWikiPageValue ) {
+		if ( $this->m_nodeLabel === self::NODELABEL_DISPLAYTITLE && $object instanceof SMWWikiPageValue ) {
 			$objectDisplayTitle = $object->getDisplayTitle();
 			if ( !empty( $objectDisplayTitle )) {
 				$nodeLabel = $this->getWordWrappedText( $objectDisplayTitle, $this->m_wordWrapLimit );
@@ -228,9 +234,9 @@ class SRFGraph extends SMWResultPrinter {
 
 		if ( $this->m_graphLink ) {
 			if( $nodeLabel === '' ) {
-                $graphInput .= " \"$text\" [URL = \"$nodeLinkURL\"]; ";
+				$graphInput .= " \"$text\" [URL = \"$nodeLinkURL\"]; ";
 			} else {
-                $graphInput .= " \"$text\" [URL = \"$nodeLinkURL\", label = \"$nodeLabel\"]; ";
+				$graphInput .= " \"$text\" [URL = \"$nodeLinkURL\", label = \"$nodeLabel\"]; ";
 			}
 		}
 
@@ -395,9 +401,9 @@ class SRFGraph extends SMWResultPrinter {
 		];
 
 		$params['nodelabel'] = [
-			'type' => 'string',
-			'default' => '',
+			'default' => [],
 			'message' => 'srf-paramdesc-nodelabel',
+			'values' => self::$NODE_LABELS,
 		];
 
 		return $params;

--- a/formats/graphviz/SRF_Graph.php
+++ b/formats/graphviz/SRF_Graph.php
@@ -79,6 +79,7 @@ class SRFGraph extends SMWResultPrinter {
 	protected $m_nodeShape;
 	protected $m_parentRelation;
 	protected $m_wordWrapLimit;
+	protected $m_nodeLabel;
 
 	/**
 	 * (non-PHPdoc)
@@ -104,6 +105,8 @@ class SRFGraph extends SMWResultPrinter {
 
 		$this->m_nodeShape = $params['nodeshape'];
 		$this->m_wordWrapLimit = $params['wordwraplimit'];
+
+		$this->m_nodeLabel = $params['nodelabel'];
 	}
 
 	protected function getResultText( SMWQueryResult $res, $outputmode ) {
@@ -207,6 +210,7 @@ class SRFGraph extends SMWResultPrinter {
 	 */
 	protected function getGVForDataValue( SMWDataValue $object, $outputmode, $isName, $name, $labelName ) {
 		$graphInput = '';
+		$nodeLabel = '';
 		$text = $object->getShortText( $outputmode );
 
 		if ( $this->m_graphLink ) {
@@ -215,8 +219,19 @@ class SRFGraph extends SMWResultPrinter {
 
 		$text = $this->getWordWrappedText( $text, $this->m_wordWrapLimit );
 
+		if ( $this->m_nodeLabel === 'displaytitle' && $object instanceof SMWWikiPageValue ) {
+			$objectDisplayTitle = $object->getDisplayTitle();
+			if ( !empty( $objectDisplayTitle )) {
+				$nodeLabel = $this->getWordWrappedText( $objectDisplayTitle, $this->m_wordWrapLimit );
+			}
+		}
+
 		if ( $this->m_graphLink ) {
-			$graphInput .= " \"$text\" [URL = \"$nodeLinkURL\"]; ";
+			if( $nodeLabel === '' ) {
+                $graphInput .= " \"$text\" [URL = \"$nodeLinkURL\"]; ";
+			} else {
+                $graphInput .= " \"$text\" [URL = \"$nodeLinkURL\", label = \"$nodeLabel\"]; ";
+			}
 		}
 
 		if ( !$isName ) {
@@ -377,6 +392,12 @@ class SRFGraph extends SMWResultPrinter {
 			'default' => 25,
 			'message' => 'srf-paramdesc-graph-wwl',
 			'manipulatedefault' => false,
+		];
+
+		$params['nodelabel'] = [
+			'type' => 'string',
+			'default' => '',
+			'message' => 'srf-paramdesc-nodelabel',
 		];
 
 		return $params;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -351,5 +351,6 @@
 	"srf-error-gantt-theme" : "The '''theme''' you have choosen is not supported",
 	"srf-error-gantt-sortkey" : "The '''sortkey''' you have choosen is not supported",
 	"srf-error-gantt-mermaid-not-installed": "Mermaid Extension needs to be installed.",
-	"srf-printername-gantt": "Gantt"
+	"srf-printername-gantt": "Gantt",
+	"srf-paramdesc-nodelabel": "Use a graph node label. Allowed values: displaytitle."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -367,5 +367,6 @@
 	"srf-error-gantt-theme": "This is an error message.",
 	"srf-error-gantt-sortkey": "This is an error message.",
 	"srf-error-gantt-mermaid-not-installed": "This is an error message.",
-	"srf-printername-gantt": "{{doc-smwformat|gantt}}"
+	"srf-printername-gantt": "{{doc-smwformat|gantt}}",
+	"srf-paramdesc-nodelabel": "{{doc-paramdesc|nodelabel}}\n{{doc-important|Do not translate the possible parameters: \"displaytitle\".}}"
 }


### PR DESCRIPTION
This PR addresses or contains:
- Adds `nodelabel` parameter with `displaytitle` option based on [DISPLAYTITLE](https://www.mediawiki.org/wiki/Extension:Display_Title). It allows to display correct page titles on graph nodes.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed