### PR TITLE
[CI] Fix `ResourceLoader` construction (MW 1.33+), refs 501

### DIFF
--- a/tests/phpunit/Integration/ResourcesTest.php
+++ b/tests/phpunit/Integration/ResourcesTest.php
@@ -34,7 +34,15 @@ class ResourcesTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function moduleDataProvider() {
-		$resourceLoader = new ResourceLoader();
+		
+		// #501
+		// MW 1.33+
+		if ( class_exists( '\MediaWiki\MediaWikiServices' ) && method_exists( '\MediaWiki\MediaWikiServices', 'getResourceLoader' ) ) {
+			$resourceLoader = \MediaWiki\MediaWikiServices::getInstance()->getResourceLoader();
+		} else {
+			$resourceLoader = new ResourceLoader();
+		}
+
 		$context = ResourceLoaderContext::newDummyContext();
 		$modules = $this->getSRFResourceModules();
 


### PR DESCRIPTION
This PR is made in reference to: #501

This PR addresses or contains:

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #501
