### PR TITLE
Add `filename` to `format=vcard`, refs 371

### DIFF
--- a/src/vCard/vCardFileExportPrinter.php
+++ b/src/vCard/vCardFileExportPrinter.php
@@ -57,7 +57,14 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	 */
 	public function getFileName( QueryResult $queryResult ) {
 
-		if ( $this->getSearchLabel( SMW_OUTPUT_WIKI ) != '' ) {
+		if ( $this->params['filename'] !== '' ) {
+
+			if ( strpos( $this->params['filename'], '.vcf' ) === false ) {
+				$this->params['filename'] .= '.vcf';
+			}
+
+			return str_replace( ' ', '_', $this->params['filename'] );
+		} elseif ( $this->getSearchLabel( SMW_OUTPUT_WIKI ) != '' ) {
 			return str_replace( ' ', '_', $this->getSearchLabel( SMW_OUTPUT_WIKI ) ) . '.vcf';
 		}
 
@@ -73,6 +80,24 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	 */
 	public function getQueryMode( $context ) {
 		return ( $context == QueryProcessor::SPECIAL_PAGE ) ? Query::MODE_INSTANCES : Query::MODE_NONE;
+	}
+
+	/**
+	 * @see ResultPrinter::getParamDefinitions
+	 *
+	 * @since 1.8
+	 *
+	 * {@inheritDoc}
+	 */
+	public function getParamDefinitions( array $definitions ) {
+		$params = parent::getParamDefinitions( $definitions );
+
+		$params['filename'] = [
+			'message' => 'smw-paramdesc-filename',
+			'default' => 'vCard.vcf',
+		];
+
+		return $params;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,3 +14,7 @@ $autoloader = require $path;
 $autoloader->addPsr4( 'SRF\\Tests\\', __DIR__ . '/phpunit' );
 $autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );
 $autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );
+
+$autoloader->addClassMap( [
+	'SRF\Tests\ResultPrinterReflector'             => __DIR__ . '/phpunit/ResultPrinterReflector.php',
+] );

--- a/tests/phpunit/ResultPrinterReflector.php
+++ b/tests/phpunit/ResultPrinterReflector.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SRF\Tests;
+
+use ReflectionClass;
+use SMW\Query\ResultPrinter;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class ResultPrinterReflector {
+
+	/**
+	 * Helper method sets result printer parameters
+	 *
+	 * @param ResultPrinter $instance
+	 * @param array $parameters
+	 *
+	 * @return ResultPrinter
+	 */
+	public function addParameters( ResultPrinter $instance, array $parameters ) {
+
+		$reflector = new ReflectionClass( $instance );
+		$params = $reflector->getProperty( 'params' );
+		$params->setAccessible( true );
+		$params->setValue( $instance, $parameters );
+
+		if ( isset( $parameters['searchlabel'] ) ) {
+			$searchlabel = $reflector->getProperty( 'mSearchlabel' );
+			$searchlabel->setAccessible( true );
+			$searchlabel->setValue( $instance, $parameters['searchlabel'] );
+		}
+
+		if ( isset( $parameters['headers'] ) ) {
+			$searchlabel = $reflector->getProperty( 'mShowHeaders' );
+			$searchlabel->setAccessible( true );
+			$searchlabel->setValue( $instance, $parameters['headers'] );
+		}
+
+		return $instance;
+	}
+
+	public function invoke( ResultPrinter $instance, $queryResult, $outputMode ) {
+
+		$reflector = new ReflectionClass(  $instance );
+		$method = $reflector->getMethod( 'getResultText' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $instance, $queryResult, $outputMode );
+	}
+
+}

--- a/tests/phpunit/Unit/vCard/vCardFileExportPrinterTest.php
+++ b/tests/phpunit/Unit/vCard/vCardFileExportPrinterTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SRF\Tests\BibTex;
+namespace SRF\Tests\vCard;
 
-use SRF\BibTex\BibTexFileExportPrinter;
+use SRF\vCard\vCardFileExportPrinter;
 use SRF\Tests\ResultPrinterReflector;
 
 /**
- * @covers \SRF\BibTex\BibTexFileExportPrinter
+ * @covers \SRF\vCard\vCardFileExportPrinter
  * @group semantic-result-formats
  *
  * @license GNU GPL v2+
@@ -14,7 +14,7 @@ use SRF\Tests\ResultPrinterReflector;
  *
  * @author mwjames
  */
-class BibTexFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
+class vCardFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
 
 	private $queryResult;
 	private $resultPrinterReflector;
@@ -32,8 +32,8 @@ class BibTexFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
 	public function testCanConstruct() {
 
 		$this->assertInstanceOf(
-			BibTexFileExportPrinter::class,
-			new BibTexFileExportPrinter( 'bibtex' )
+			vCardFileExportPrinter::class,
+			new vCardFileExportPrinter( 'vcard' )
 		);
 	}
 
@@ -46,8 +46,8 @@ class BibTexFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
 			'filename' => $filename
 		];
 
-		$instance = new BibTexFileExportPrinter(
-			'bibtex'
+		$instance = new vCardFileExportPrinter(
+			'vcard'
 		);
 
 		$this->resultPrinterReflector->addParameters( $instance, $parameters );
@@ -60,12 +60,12 @@ class BibTexFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
 
 	public function testGetMimeType() {
 
-		$instance = new BibTexFileExportPrinter(
-			'bibtex'
+		$instance = new vCardFileExportPrinter(
+			'vcard'
 		);
 
 		$this->assertEquals(
-			'text/bibtex',
+			'text/x-vcard',
 			$instance->getMimeType( $this->queryResult )
 		);
 	}
@@ -74,17 +74,17 @@ class BibTexFileExportPrinterTest extends \PHPUnit_Framework_TestCase {
 
 		yield[
 			'',
-			'BibTeX.bib'
+			'vCard.vcf'
 		];
 
 		yield[
 			'foo',
-			'foo.bib'
+			'foo.vcf'
 		];
 
 		yield[
-			'foo.bib',
-			'foo.bib'
+			'foo.vcf',
+			'foo.vcf'
 		];
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #371

This PR addresses or contains:

- Adds `filename` as parameter to the `format=vcard`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

Fixes #371
