### PR TITLE
[ical] Add `DateParser`

### DIFF
--- a/src/iCalendar/DateParser.php
+++ b/src/iCalendar/DateParser.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace SRF\iCalendar;
+
+use SMWDataValueFactory as DataValueFactory;
+use SMWTimeValue as TimeValue;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.1
+ */
+class DateParser {
+
+	/**
+	 * Extract a date string formatted for iCalendar from a SMWTimeValue object.
+	 *
+	 * @since 3.1
+	 *
+	 * @param TimeValue $dataValue
+	 * @param boolean $isEnd
+	 *
+	 * @return string
+	 */
+	public function parseDate( TimeValue $dataValue, $isEnd = false ) {
+		$year = $dataValue->getYear();
+
+		// ISO range is limited to four digits
+		if ( ( $year > 9999 ) || ( $year < -9998 ) ) {
+			return '';
+		}
+
+		$year = number_format( $year, 0, '.', '' );
+		$time = str_replace( ':', '', $dataValue->getTimeString( false ) );
+
+		// increment by one day, compute date to cover leap years etc.
+		if ( ( $time == false ) && ( $isEnd ) ) {
+			$dataValue = DataValueFactory::getInstance()->newDataValueByType(
+				'_dat',
+				$dataValue->getWikiValue() . 'T00:00:00-24:00'
+			);
+		}
+
+		$month = $dataValue->getMonth();
+
+		if ( strlen( $month ) == 1 ) {
+			$month = '0' . $month;
+		}
+
+		$day = $dataValue->getDay();
+
+		if ( strlen( $day ) == 1 ) {
+			$day = '0' . $day;
+		}
+
+		$result = $year . $month . $day;
+
+		if ( $time != false ) {
+			$result .= "T$time";
+		}
+
+		return $result;
+	}
+
+}

--- a/tests/phpunit/Unit/iCalendar/DateParserTest.php
+++ b/tests/phpunit/Unit/iCalendar/DateParserTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SRF\Tests\iCalendar;
+
+use SRF\iCalendar\DateParser;
+
+/**
+ * @covers \SRF\iCalendar\DateParser
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.1
+ *
+ * @author mwjames
+ */
+class DateParserTest extends \PHPUnit_Framework_TestCase {
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			DateParser::class,
+			new DateParser()
+		);
+	}
+
+	public function testParseDate_Year() {
+
+		$timeValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$timeValue->expects( $this->any() )
+			->method( 'getYear' )
+			->will( $this->returnValue( 2000 ) );
+
+		$instance = new DateParser();
+
+		$this->assertSame(
+			'20000101',
+			$instance->parseDate( $timeValue, true )
+		);
+	}
+
+	public function testParseDate_Year_Month_Day_Time() {
+
+		$timeValue = $this->getMockBuilder( '\SMWTimeValue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$timeValue->expects( $this->any() )
+			->method( 'getYear' )
+			->will( $this->returnValue( 2000 ) );
+
+		$timeValue->expects( $this->any() )
+			->method( 'getMonth' )
+			->will( $this->returnValue( 12 ) );
+
+		$timeValue->expects( $this->any() )
+			->method( 'getDay' )
+			->will( $this->returnValue( 12 ) );
+
+		$timeValue->expects( $this->any() )
+			->method( 'getTimeString' )
+			->will( $this->returnValue( '12:01:01' ) );
+
+		$instance = new DateParser();
+
+		$this->assertSame(
+			'20001212T120101',
+			$instance->parseDate( $timeValue, true )
+		);
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:

- Isolates the date parsing and moves it into a separate class, adds a unit test, and fixes a copy-paste error `DataValueFactoryg::getInstance`

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
