### PR TITLE
[ical] Add `IcalFormatter`, refs 340

### DIFF
--- a/src/iCalendar/DateParser.php
+++ b/src/iCalendar/DateParser.php
@@ -7,14 +7,14 @@ use SMWTimeValue as TimeValue;
 
 /**
  * @license GNU GPL v2+
- * @since 3.1
+ * @since 3.2
  */
 class DateParser {
 
 	/**
 	 * Extract a date string formatted for iCalendar from a SMWTimeValue object.
 	 *
-	 * @since 3.1
+	 * @since 3.2
 	 *
 	 * @param TimeValue $dataValue
 	 * @param boolean $isEnd

--- a/src/iCalendar/IcalFormatter.php
+++ b/src/iCalendar/IcalFormatter.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SRF\iCalendar;
+
+use Exception;
+
+/**
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class IcalFormatter {
+
+	/**
+	 * @var IcalTimezoneFormatter
+	 */
+	private $icalTimezoneFormatter;
+
+	/**
+	 * @var string
+	 */
+	private $calendarName;
+
+	/**
+	 * @var string
+	 */
+	private $description;
+
+	/**
+	 * @var []
+	 */
+	private $events = [];
+
+	/**
+	 * @since 3.0
+	 */
+	public function __construct( IcalTimezoneFormatter $icalTimezoneFormatter ) {
+		$this->icalTimezoneFormatter = $icalTimezoneFormatter;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $calendarName
+	 */
+	public function setCalendarName( $calendarName ) {
+		$this->calendarName = $calendarName;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param string $description
+	 */
+	public function setDescription( $description ) {
+		$this->description = $description;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @param array $params
+	 */
+	public function addEvent( array $params ) {
+
+		$event = '';
+		$event .= "BEGIN:VEVENT\r\n";
+
+		if ( isset( $params['summary'] ) ) {
+			$event .= "SUMMARY:" . $this->escape( $params['summary'] ) . "\r\n";
+		}
+
+		if ( isset( $params['url'] ) ) {
+			$event .= "URL:" . $params['url'] . "\r\n";
+			$event .= "UID:" . $params['url'] . "\r\n";
+		}
+
+		if ( array_key_exists( 'start', $params ) ) {
+			$event .= "DTSTART:" . $params['start'] . "\r\n";
+		}
+
+		if ( array_key_exists( 'end', $params ) ) {
+			$event .= "DTEND:" . $params['end'] . "\r\n";
+		}
+
+		if ( array_key_exists( 'location', $params ) ) {
+			$event .= "LOCATION:" . $this->escape( $params['location'] ) . "\r\n";
+		}
+
+		if ( array_key_exists( 'description', $params ) ) {
+			$event .= "DESCRIPTION:" . $this->escape( $params['description'] ) . "\r\n";
+		}
+
+		if ( isset( $params['timestamp'] ) ) {
+			$t = strtotime( str_replace( 'T', ' ', $params['timestamp'] ) );
+			$event .= "DTSTAMP:" . date( "Ymd", $t ) . "T" . date( "His", $t ) . "\r\n";
+		}
+
+		if ( isset( $params['sequence'] ) ) {
+			$event .= "SEQUENCE:" . $params['sequence'] . "\r\n";
+		}
+
+		$event .= "END:VEVENT\r\n";
+
+		$this->events[] = $event;
+	}
+
+	/**
+	 * @since 3.2
+	 *
+	 * @return string
+	 */
+	public function getIcal() {
+
+		$result = '';
+
+		$result .= "BEGIN:VCALENDAR\r\n";
+		$result .= "PRODID:-//SMW Project//Semantic Result Formats\r\n";
+		$result .= "VERSION:2.0\r\n";
+		$result .= "METHOD:PUBLISH\r\n";
+		$result .= "X-WR-CALNAME:" . $this->calendarName . "\r\n";
+
+		if ( $this->description !== null ) {
+			$result .= "X-WR-CALDESC:" . $this->description . "\r\n";
+		}
+
+		$result .= $this->icalTimezoneFormatter->getTransitions();
+
+		foreach ( $this->events as $event ) {
+			$result .= $event;
+		}
+
+		$result .= "END:VCALENDAR\r\n";
+		$this->events = [];
+
+		return $result;
+	}
+
+	/**
+	 * Implements esaping of special characters for iCalendar properties of type
+	 * TEXT. This is defined in RFC2445 Section 4.3.21.
+	 */
+	private function escape( $text ) {
+		// Note that \\ is a PHP escaped single \ here
+		return str_replace( [ "\\", "\n", ";", "," ], [ "\\\\", "\\n", "\\;", "\\," ], $text );
+	}
+
+}

--- a/tests/phpunit/Unit/iCalendar/DateParserTest.php
+++ b/tests/phpunit/Unit/iCalendar/DateParserTest.php
@@ -9,7 +9,7 @@ use SRF\iCalendar\DateParser;
  * @group semantic-result-formats
  *
  * @license GNU GPL v2+
- * @since 3.1
+ * @since 3.2
  *
  * @author mwjames
  */

--- a/tests/phpunit/Unit/iCalendar/IcalFormatterTest.php
+++ b/tests/phpunit/Unit/iCalendar/IcalFormatterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SRF\Tests\iCalendar;
+
+use SMW\Tests\TestEnvironment;
+use SRF\iCalendar\IcalFormatter;
+
+/**
+ * @covers \SRF\iCalendar\IcalFormatter
+ * @group semantic-result-formats
+ *
+ * @license GNU GPL v2+
+ * @since 3.2
+ *
+ * @author mwjames
+ */
+class IcalFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	private $stringValidator;
+	private $icalTimezoneFormatter;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->icalTimezoneFormatter = $this->getMockBuilder( '\SRF\iCalendar\IcalTimezoneFormatter' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->stringValidator = TestEnvironment::newValidatorFactory()->newStringValidator();
+	}
+
+	public function testCanConstruct() {
+
+		$this->assertInstanceOf(
+			IcalFormatter::class,
+			new IcalFormatter( $this->icalTimezoneFormatter )
+		);
+	}
+
+	/**
+	 * @dataProvider paramsProvider
+	 */
+	public function testGetIcal( $params, $events, $expected ) {
+
+		$instance = new IcalFormatter(
+			$this->icalTimezoneFormatter
+		);
+
+		$instance->setCalendarName( $params['calendarname'] );
+		$instance->setDescription( $params['description'] );
+
+		foreach ( $events as $event ) {
+			$instance->addEvent( $event );
+		}
+
+		$this->stringValidator->assertThatStringContains(
+			$expected,
+			$instance->getIcal()
+		);
+	}
+
+	public function paramsProvider() {
+
+		yield [
+			[
+				'calendarname' => 'FooCalendar',
+				'description'  => 'Calendar description'
+			],
+			[
+				[
+					'summary'     => 'summary',
+					'url'         => 'http://example.org/Test_1',
+					'start'       => '1 Jan 2000',
+					'end'         => '2 Jan 2000',
+					'location'    => 'FooPlanet',
+					'description' => 'Event description',
+					'timestamp'   => '1566476717',
+					'sequence'    => '123'
+				]
+			],
+			"BEGIN:VCALENDAR\r\n" .
+			"PRODID:-//SMW Project//Semantic Result Formats\r\n" .
+			"VERSION:2.0\r\n" .
+			"METHOD:PUBLISH\r\n" .
+			"X-WR-CALNAME:FooCalendar\r\n" .
+			"X-WR-CALDESC:Calendar description\r\n" .
+			"BEGIN:VEVENT\r\n" .
+			"SUMMARY:summary\r\n" .
+			"URL:http://example.org/Test_1\r\n" .
+			"UID:http://example.org/Test_1\r\n" .
+			"DTSTART:1 Jan 2000\r\n" .
+			"DTEND:2 Jan 2000\r\nLOCATION:FooPlanet\r\n" .
+			"DESCRIPTION:Event description\r\n" .
+			"DTSTAMP:19700101T000000\r\n" .
+			"SEQUENCE:123\r\n" .
+			"END:VEVENT\r\n" .
+			"END:VCALENDAR"
+		];
+	}
+
+}


### PR DESCRIPTION
This PR is made in reference to: #340

This PR addresses or contains:

- Isolates the ical specific output formatting and moves it to a separate class that can be tested autonomously.

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed
