### PR TITLE
Use `sequence_map` for author/bibtex test

### DIFF
--- a/tests/phpunit/Integration/JSONScript/Fixtures/bibtex-sequence-map.json
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/bibtex-sequence-map.json
@@ -1,0 +1,9 @@
+{
+    "type": "PROPERTY_PROFILE_SCHEMA",
+    "profile": {
+        "sequence_map": true
+    },
+    "tags": [
+        "property profile"
+    ]
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/bibtex-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/bibtex-01.json
@@ -2,9 +2,16 @@
 	"description": "Test `format=bibtex`",
 	"setup": [
 		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Profile:AuthorSequence",
+			"contents": {
+				"import-from": "/../Fixtures/bibtex-sequence-map.json"
+			}
+		},
+		{
 			"page": "Has author",
 			"namespace": "SMW_NS_PROPERTY",
-			"contents": "[[Has type::Text]]"
+			"contents": "[[Has type::Text]] [[Profile schema::Profile:AuthorSequence]]"
 		},
 		{
 			"page": "Has title",
@@ -148,7 +155,8 @@
 		"wgLang": "en",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
-			"SMW_NS_PROPERTY": true
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
 		}
 	},
 	"meta": {


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4226

This PR addresses or contains:

- This is an example for the use of a "sequence map", while MySQL/MariaDB, and SQLite do return a specific sequence by default, PostgreSQL would fail that assumption and the test as well
- After adding a `sequence_map` for the `Has author` property the expected author sequence is produced on all platforms equally

This PR includes:
- [x] Tests (unit/integration)
- [x] CI build passed

## Note

```
1) SRF\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest::testCaseFile with data set "bibtex-01.json" ('/home/travis/build/SemanticMe...1.json')
Failed "#2 `format=bibtex` multiple authors (bibtex-01-2.bib)" for StringContains:
==== (actual) ====
@Book{stegun1964homf,
  address = "New York",
  author = "Irene A. Stegun and Milton Abramowitz",
  edition = "ninth Dover printing, tenth GPO printing",
  publisher = "Dover",
  title = "Handbook of Mathematical Functions",
  year = "1964",
}
==== (expected) ====
[ @Book{abramowitz1964homf,
  address = "New York",
  author = "Milton Abramowitz and Irene A. Stegun",
  edition = "ninth Dover printing, tenth GPO printing",
  publisher = "Dover",
  title = "Handbook of Mathematical Functions",
  year = "1964",
} ]
```
