### PR TITLE
Remove doc types from fields

### DIFF
--- a/src/Graph/GraphOptions.php
+++ b/src/Graph/GraphOptions.php
@@ -16,59 +16,26 @@ namespace SRF\Graph;
 
 class GraphOptions {
 
-	/**
-	 * @var string
-	 */
 	private $graphName;
 
-	/**
-	 * @var string
-	 */
 	private $graphSize;
 
-	/**
-	 * @var string
-	 */
 	private $nodeShape;
 
-	/**
-	 * @var string
-	 */
 	private $nodeLabel;
 
-	/**
-	 * @var string
-	 */
 	private $rankDir;
 
-	/**
-	 * @var int
-	 */
 	private $wordWrapLimit;
 
-	/**
-	 * @var string
-	 */
 	private $parentRelation;
 
-	/**
-	 * @var boolean
-	 */
 	private $enableGraphLink;
 
-	/**
-	 * @var boolean
-	 */
 	private $showGraphLabel;
 
-	/**
-	 * @var boolean
-	 */
 	private $showGraphColor;
 
-	/**
-	 * @var boolean
-	 */
 	private $showGraphLegend;
 
 	public function __construct( $options ) {


### PR DESCRIPTION
This PR is made in reference to: https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/538

This PR addresses or contains:
- Remove doc types from fields in GraphOptions