### PR TITLE
Use getPreferredCaption() to get the "displaytitle" for graph nodes

### DIFF
--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -160,7 +160,7 @@ class GraphPrinter extends ResultPrinter {
 				// create SRF\GraphNode for column 0
 				if ( $i == 0 ) {
 					$node = new GraphNode( $object->getShortWikiText() );
-					$node->setLabel( $object->getDisplayTitle() );
+					$node->setLabel( $object->getPreferredCaption() );
 					$this->nodes[] = $node;
 				} else {
 					$node->addParentNode( $resultArray->getPrintRequest()->getLabel(), $object->getShortWikiText() );


### PR DESCRIPTION
This PR is made in reference to:https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/538#discussion_r319732598

This PR addresses or contains:
- Use getPreferredCaption() to get the "displaytitle" for graph nodes
