### PR TITLE
Mediaplayer: Replace deprecated methods (+ some cleanup), tests

### DIFF
--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -174,7 +174,7 @@ class MediaPlayer extends ResultPrinter {
 	private function getMediaSource( Title $title ) {
 
 		// Find the file source
-		$source = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
+		$source = $this->findFile( $title );
 
 		if ( $source ) {
 			// $source->getExtension() returns ogg even though it is a ogv/oga (same goes for m4p) file
@@ -236,7 +236,7 @@ class MediaPlayer extends ResultPrinter {
 					$mediaType = 'video';
 
 					// Get the cover art image url
-					$source = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
+					$source = $this->findFile( $title );
 
 					return $source->getUrl();
 				}
@@ -362,5 +362,19 @@ class MediaPlayer extends ResultPrinter {
 		];
 
 		return $params;
+	}
+
+	/**
+	 * @param Title $title
+	 *
+	 * @return bool|File
+	 */
+	private function findFile( Title $title ) {
+
+		if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
+			return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
+		}
+
+		return wfFindFile( $title ); // TODO: Remove when min MW version is 1.34
 	}
 }

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -308,7 +308,7 @@ class MediaPlayer extends ResultPrinter {
 		];
 
 		$requireHeadItem = [ $ID => FormatJson::encode( $output ) ];
-		SMWOutputs::requireHeadItem( $ID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $ID, Skin::makeVariablesScript( $requireHeadItem, false ) );
 
 		SMWOutputs::requireResource( 'ext.jquery.jplayer.skin.' . $this->params['theme'] );
 		SMWOutputs::requireResource( 'ext.srf.formats.media' );

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -5,12 +5,14 @@ namespace SRF;
 use File;
 use FormatJson;
 use Html;
+use MediaWiki\MediaWikiServices;
 use Skin;
 use SMW\ResultPrinter;
 use SMWDataItem;
 use SMWDataValue;
 use SMWOutputs;
 use SMWQueryResult;
+use SMWResultArray;
 use SRFUtils;
 use Title;
 
@@ -18,7 +20,7 @@ use Title;
  * HTML5 Audio / Video media query printer
  *
  * This printer integrates jPlayer which is a HTML5 Audio / Video
- * Javascript libray under GPL/MIT license.
+ * Javascript library under GPL/MIT license.
  *
  * @see http://www.semantic-mediawiki.org/wiki/Help:Media_format
  *
@@ -70,17 +72,17 @@ class MediaPlayer extends ResultPrinter {
 		$data = $this->getResultData( $result, $outputMode );
 
 		// Check if the data processing returned any results otherwise just bailout
-		if ( $data === [] ) {
-			if ( $this->params['default'] !== '' ) {
-				return $this->params['default'];
-			} else {
-				$result->addErrors( [ $this->msg( 'srf-no-results' )->inContentLanguage()->text() ] );
-				return '';
-			}
-		} else {
+		if ( $data !== [] ) {
 			// Return formatted results
 			return $this->getFormatOutput( $data );
 		}
+
+		if ( $this->params[ 'default' ] !== '' ) {
+			return $this->params[ 'default' ];
+		}
+
+		$result->addErrors( [ $this->msg( 'srf-no-results' )->inContentLanguage()->text() ] );
+		return '';
 	}
 
 	/**
@@ -165,11 +167,15 @@ class MediaPlayer extends ResultPrinter {
 	 * @since 1.9
 	 *
 	 * @param Title $title
+	 *
+	 * @return string[]
+	 *
 	 */
 	private function getMediaSource( Title $title ) {
 
 		// Find the file source
-		$source = wfFindFile( $title );
+		$source = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
+
 		if ( $source ) {
 			// $source->getExtension() returns ogg even though it is a ogv/oga (same goes for m4p) file
 			// this doesn't help much therefore we do it ourselves
@@ -197,15 +203,16 @@ class MediaPlayer extends ResultPrinter {
 	/**
 	 * Returns single data value item
 	 *
-	 * @since 1.9
-	 *
 	 * @param string $label
-	 * @param integer $type
 	 * @param SMWDataValue $dataValue
 	 * @param string $mediaType
 	 * @param string $mimeType
 	 *
+	 * @param $rowData
+	 *
 	 * @return mixed
+	 * @since 1.9
+	 *
 	 */
 	private function getDataValueItem( &$label, SMWDataValue $dataValue, &$mediaType, &$mimeType, &$rowData ) {
 
@@ -229,13 +236,14 @@ class MediaPlayer extends ResultPrinter {
 					$mediaType = 'video';
 
 					// Get the cover art image url
-					$source = wfFindFile( $title );
+					$source = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
+
 					return $source->getUrl();
 				}
 			}
 		}
 
-		if ( $type == SMWDataItem::TYPE_URI ) {
+		if ( $type === SMWDataItem::TYPE_URI ) {
 
 			$source = $dataItem->getURI();
 			$mimeType = '';

--- a/tests/phpunit/Integration/JSONScript/Fixtures/dummy.mp3
+++ b/tests/phpunit/Integration/JSONScript/Fixtures/dummy.mp3
@@ -1,0 +1,1 @@
+ID3 dummy

--- a/tests/phpunit/Integration/JSONScript/TestCases/media-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/media-01.json
@@ -1,0 +1,78 @@
+{
+	"description": "Test `format=media` with file upload",
+	"setup": [
+		{
+			"namespace": "NS_FILE",
+			"page": "Dummy.mp3",
+			"contents": {
+				"upload": {
+					"file": "/../Fixtures/dummy.mp3",
+					"text": "[[Category:Mediaplayer test]]"
+				}
+			}
+		},
+		{
+			"page": "Setup/Mediaplayer test 01",
+			"contents": "[[Has source::File:Dummy.mp3]]"
+		},
+		{
+			"page": "Test/Mediaplayer test 01",
+			"contents": "{{#ask: [[Category:Mediaplayer test]] |?Title=title |?Has cover art=poster |?Has artists=artist |default=''No valid media found.'' |format=media}}"
+		},
+		{
+			"page": "Test/Mediaplayer test 02",
+			"contents": "{{#ask: [[Has source::+]] |?Has source=source |?Has title=title |?Has artist=artist |default=''No valid media found.'' |format=media}}"
+		},
+		{
+			"page": "Test/Mediaplayer test 03",
+			"contents": "{{#ask: [[File:Dummy.mp3]] |default=''No valid media found.'' |format=media}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#1 (Media source is the subject itself)",
+			"subject": "Test/Mediaplayer test 01",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-media\"><div class=\"srf-spinner mw-small-spinner\"><span class=\"srf-processing-text\">Loading...</span></div><div id=\"srf-.*\" class=\"media-container\" style=\"display:none;\"></div></div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 (Media source is not the subject itself)",
+			"subject": "Test/Mediaplayer test 02",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-media\"><div class=\"srf-spinner mw-small-spinner\"><span class=\"srf-processing-text\">Loading...</span></div><div id=\"srf-.*\" class=\"media-container\" style=\"display:none;\"></div></div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 (Single mode)",
+			"subject": "Test/Mediaplayer test 03",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-media\"><div class=\"srf-spinner mw-small-spinner\"><span class=\"srf-processing-text\">Loading...</span></div><div id=\"srf-.*\" class=\"media-container\" style=\"display:none;\"></div></div>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_FILE": true,
+			"SMW_NS_PROPERTY": true
+		},
+		"wgFileExtensions": [ "mp3" ]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- Replace deprecated MW methods
- some cleanup
- simple tests

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
