### PR TITLE
Calendar format: Set table.month_calendar width to 100%

### DIFF
--- a/formats/calendar/resources/ext.srf.calendar.css
+++ b/formats/calendar/resources/ext.srf.calendar.css
@@ -18,6 +18,7 @@ table.navigation_table tr td.nav_form {
 }
 table.month_calendar {
 	border-collapse: collapse;
+	width:100%;
 }
 table.month_calendar tr {
 }


### PR DESCRIPTION
This PR is made in reference to: none

This PR addresses or contains:
- table.navigation_table width is set to 100% but table.month_calendar is not
- This leaves a blank area below, to the right, of table.navigation_table. Also, to the right of table.month_calendar

This PR includes:
- Set table.month_calendar width to 100%
