### PR TITLE
Replace deprecated DB_SLAVE constant

### DIFF
--- a/formats/Exhibit/SRF_Exhibit.php
+++ b/formats/Exhibit/SRF_Exhibit.php
@@ -71,7 +71,7 @@ class SRFExhibit extends SMWResultPrinter {
 			$remote = true;
 
 			// fetch interwiki link
-			$dbr = &wfGetDB( DB_SLAVE );
+			$dbr = &wfGetDB( DB_REPLICA );
 			$cl = $dbr->tableName( 'interwiki' );
 			$dbres = $dbr->select( $cl, 'iw_url', "iw_prefix='" . $this->params['remote'] . "'", __METHOD__, [] );
 			$row = $dbr->fetchRow( $dbres );


### PR DESCRIPTION
This constant was renamed to DB_REPLICA and remained as deprecated alias since MW 1.28.

It was completely [dropped in MW 1.34](https://gerrit.wikimedia.org/r/#/c/mediawiki/core/+/443747/)