### PR TITLE
[Graph] Fix Mermaid 2.2.0 now requires MW 1.33+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=REL1_34; SMW=~3.1@dev; TYPE=coverage
+    - env: DB=mysql; MW=REL1_33; SMW=~3.1@dev; TYPE=coverage
       php: 7.3
     - env: DB=sqlite; MW=REL1_31; SMW=~3.0; MERMAID=2.1.0
       php: 7.1
@@ -15,7 +15,7 @@ matrix:
       php: 7.1
     - env: DB=postgres; MW=REL1_32; SMW=~3.0@dev
       php: 7.2
-    - env: DB=mysql; MW=REL1_33; SMW=~3.0@dev; MERMAID=dev-master
+    - env: DB=mysql; MW=REL1_33; SMW=~3.0@dev; MERMAID=2.2.0
       php: 7.3
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 matrix:
   fast_finish: true
   include:
-    - env: DB=mysql; MW=master; SMW=~3.1@dev; TYPE=coverage
+    - env: DB=mysql; MW=REL1_34; SMW=~3.1@dev; TYPE=coverage
       php: 7.3
     - env: DB=sqlite; MW=REL1_31; SMW=~3.0; MERMAID=2.1.0
       php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
   include:
     - env: DB=mysql; MW=master; SMW=~3.1@dev; TYPE=coverage
       php: 7.3
-    - env: DB=sqlite; MW=REL1_31; SMW=~3.0; MERMAID=dev-master
+    - env: DB=sqlite; MW=REL1_31; SMW=~3.0; MERMAID=2.1.0
       php: 7.1
     - env: DB=mysql; MW=REL1_31; SMW=~3.0@dev
       php: 7.1
     - env: DB=postgres; MW=REL1_32; SMW=~3.0@dev
       php: 7.2
-    - env: DB=mysql; MW=REL1_33; SMW=~3.0@dev
+    - env: DB=mysql; MW=REL1_33; SMW=~3.0@dev; MERMAID=dev-master
       php: 7.3
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -49,13 +49,13 @@
 		"mediawiki/semantic-media-wiki": "~3.0",
 		"nicmart/tree": "^0.2.7",
 		"data-values/geo": "~4.0|~3.0|~2.0",
-		"symfony/css-selector": "^3.3",
-		"mediawiki/mermaid": "~2.1"
+		"symfony/css-selector": "^3.3"
 	},
 	"suggest": {
 		"phpoffice/phpspreadsheet": "Required for 'format=spreadsheet'",
 		"phpoffice/phpexcel": "Required for 'format=excel'",
-		"mediawiki/graph-viz": "Required for 'format=graph' and 'format=process'"
+		"mediawiki/graph-viz": "Required for 'format=graph' and 'format=process'",
+		"mediawiki/mermaid": "Required for 'format=gantt'"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
This PR is made in reference to: #570

This PR addresses or contains:
- moved "mediawiki/mermaid": "~2.1" from composer.json "require" to "suggest"
- updated Travis to install a compatible Mermaid version 
- attempt to temp. avoid i#567 using MW "REL1_34"

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #570 
