### PR TITLE
MediaWiki changed handling of spaces &#160 vs. &nbsp; vs " "

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/gantt-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gantt-01.json
@@ -104,6 +104,9 @@
       "type": "parser",
       "about": "Test gantt min config",
       "subject": "Example/Gantt Diagram min config",
+      "skip-on": {
+        "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
       "assert-output": {
         "to-contain": [
           "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat&#160;%m\\/%d\\/%Y\\nsection First Section\\nTask01\\t&#160;:2019-01-01, 2019-01-15\\nTask03\\t&#160;:2019-02-01, 2019-02-15\\nTask04\\t&#160;:2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t&#160;:2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;default&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:75,&quot;titleTopMargin&quot;:25,&quot;barHeight&quot;:20,&quot;barGap&quot;:4&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
@@ -114,6 +117,9 @@
       "type": "parser",
       "about": "Test gantt when all config params set",
       "subject": "Example/Gantt Diagram config all",
+      "skip-on": {
+        "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
       "assert-output": {
         "to-contain": [
           "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat&#160;%m\\/%d\\/%Y\\nsection First Section\\nTask01\\t&#160;:2019-01-01, 2019-01-15\\nTask03\\t&#160;:2019-02-01, 2019-02-15\\nTask04\\t&#160;:2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t&#160;:2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
@@ -124,6 +130,9 @@
       "type": "parser",
       "about": "Test axis forma %m/%d/%Y",
       "subject": "Example/Gantt Diagram test axis format 1",
+      "skip-on": {
+        "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
       "assert-output": {
         "to-contain": [
           "axisFormat&#160;%m\\/%d\\/%Y"
@@ -134,6 +143,9 @@
       "type": "parser",
       "about": "Test priority mapping",
       "subject": "Example/Gantt priority mapping test",
+      "skip-on": {
+        "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
       "assert-output": {
         "to-contain": [
           "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat&#160;%m\\/%d\\/%Y\\nsection First Section\\nTask01\\t&#160;:2019-01-01, 2019-01-15\\nTask03\\t&#160;:crit, 2019-02-01, 2019-02-15\\nTask04\\t&#160;:crit, 2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t&#160;:2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
@@ -144,6 +156,9 @@
       "type": "parser",
       "about": "Test priority mapping",
       "subject": "Example/Gantt status mapping test",
+      "skip-on": {
+        "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
       "assert-output": {
         "to-contain": [
           "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat&#160;%m\\/%d\\/%Y\\nsection First Section\\nTask01\\t&#160;:2019-01-01, 2019-01-15\\nTask03\\t&#160;:active, 2019-02-01, 2019-02-15\\nTask04\\t&#160;:done, 2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t&#160;:active, 2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"

--- a/tests/phpunit/Integration/JSONScript/TestCases/gantt-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gantt-01.json
@@ -115,6 +115,19 @@
     },
     {
       "type": "parser",
+      "about": "Test gantt min config",
+      "subject": "Example/Gantt Diagram min config",
+      "skip-on": {
+        "mediawiki": [ "<1.32.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
+      "assert-output": {
+        "to-contain": [
+          "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat %m\\/%d\\/%Y\\nsection First Section\\nTask01\\t :2019-01-01, 2019-01-15\\nTask03\\t :2019-02-01, 2019-02-15\\nTask04\\t :2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t :2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;default&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:75,&quot;titleTopMargin&quot;:25,&quot;barHeight&quot;:20,&quot;barGap&quot;:4&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
+        ]
+      }
+    },
+    {
+      "type": "parser",
       "about": "Test gantt when all config params set",
       "subject": "Example/Gantt Diagram config all",
       "skip-on": {
@@ -128,6 +141,19 @@
     },
     {
       "type": "parser",
+      "about": "Test gantt when all config params set",
+      "subject": "Example/Gantt Diagram config all",
+      "skip-on": {
+        "mediawiki": [ "<1.32.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
+      "assert-output": {
+        "to-contain": [
+          "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat %m\\/%d\\/%Y\\nsection First Section\\nTask01\\t :2019-01-01, 2019-01-15\\nTask03\\t :2019-02-01, 2019-02-15\\nTask04\\t :2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t :2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
+        ]
+      }
+    },
+    {
+      "type": "parser",
       "about": "Test axis forma %m/%d/%Y",
       "subject": "Example/Gantt Diagram test axis format 1",
       "skip-on": {
@@ -136,6 +162,19 @@
       "assert-output": {
         "to-contain": [
           "axisFormat&#160;%m\\/%d\\/%Y"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test axis forma %m/%d/%Y",
+      "subject": "Example/Gantt Diagram test axis format 1",
+      "skip-on": {
+        "mediawiki": [ "<1.32.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
+      "assert-output": {
+        "to-contain": [
+          "axisFormat %m\\/%d\\/%Y"
         ]
       }
     },
@@ -155,6 +194,19 @@
     {
       "type": "parser",
       "about": "Test priority mapping",
+      "subject": "Example/Gantt priority mapping test",
+      "skip-on": {
+        "mediawiki": [ "<1.32.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
+      },
+      "assert-output": {
+        "to-contain": [
+          "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat %m\\/%d\\/%Y\\nsection First Section\\nTask01\\t :2019-01-01, 2019-01-15\\nTask03\\t :crit, 2019-02-01, 2019-02-15\\nTask04\\t :crit, 2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t :2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test priority mapping",
       "subject": "Example/Gantt status mapping test",
       "skip-on": {
         "mediawiki": [ ">1.31.x", "MediaWiki changed handling of spaces &#160 vs. &nbsp; vs \" \"" ]
@@ -162,6 +214,19 @@
       "assert-output": {
         "to-contain": [
           "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat&#160;%m\\/%d\\/%Y\\nsection First Section\\nTask01\\t&#160;:2019-01-01, 2019-01-15\\nTask03\\t&#160;:active, 2019-02-01, 2019-02-15\\nTask04\\t&#160;:done, 2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t&#160;:active, 2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
+        ]
+      }
+    },
+    {
+      "type": "parser",
+      "about": "Test priority mapping",
+      "subject": "Example/Gantt status mapping test",
+      "skip-on": {
+        "mediawiki": [ "<1.32.x", "MediaWiki changed ..." ]
+      },
+      "assert-output": {
+        "to-contain": [
+          "data-mermaid=\"&#123;&quot;content&quot;:&quot;gantt\\ndateFormat YYYY-MM-DD\\naxisFormat %m\\/%d\\/%Y\\nsection First Section\\nTask01\\t :2019-01-01, 2019-01-15\\nTask03\\t :active, 2019-02-01, 2019-02-15\\nTask04\\t :done, 2019-02-15, 2019-02-28\\nsection Second Section\\nTask02\\t :active, 2019-01-15, 2019-01-31\\n&quot;,&quot;config&quot;:&#123;&quot;theme&quot;:&quot;forest&quot;,&quot;gantt&quot;:&#123;&quot;leftPadding&quot;:130,&quot;titleTopMargin&quot;:30,&quot;barHeight&quot;:40,&quot;barGap&quot;:15&#125;&#125;&#125;\"><div class=\"mermaid-dots\"></div></div>"
         ]
       }
     }


### PR DESCRIPTION
This PR is made in reference to: #575 

Skip existing tests for MW > 1.32 and add new integration tests.