### PR TITLE
Fix warnings issued by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: php
 
+os:
+  - linux
+
 services:
   - mysql
   - postgresql
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=mysql; MW=REL1_33; SMW=~3.1@dev; TYPE=coverage


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [x] CI build passed

Fixes #
