### PR TITLE
Update ext.srf.filtered.value-filter.less

### DIFF
--- a/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
+++ b/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
@@ -68,8 +68,4 @@
 			border: solid #777777 1px;
 		}
 	}
-
-	.select2-search__field {
-		width: 100% !important;
-	}
 }


### PR DESCRIPTION
seems to be not necessary in SRF 3.1.x. On the contrary, it crops the paceholder text (can be seen in German language settings).

This PR is made in reference to: #591

This PR needs some more testing. Tested it on my wikis, but need someone to confirm nothing breaks with this PR.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
