### PR TITLE
Replace use of deprecated $wgParser

### DIFF
--- a/formats/Exhibit/SRF_Exhibit.php
+++ b/formats/Exhibit/SRF_Exhibit.php
@@ -7,6 +7,8 @@
  * @ingroup SMWQuery
  */
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Result printer using Exhibit to display query results
  *
@@ -335,7 +337,6 @@ class SRFExhibit extends SMWResultPrinter {
 
 		// prepare automatic lenses
 
-		global $wgParser;
 		$lenscounter = 0;
 		$linkcounter = 0;
 		$imagecounter = 0;
@@ -404,9 +405,10 @@ class SRFExhibit extends SMWResultPrinter {
 				}
 			}
 
-			$lenshtml = $wgParser->internalParse(
+			$parser = MediaWikiServices::getInstance()->getParser();
+			$lenshtml = $parser->internalParse(
 				$lenswikitext
-			);// $wgParser->parse($lenswikitext, $lenstitle, new ParserOptions(), true, true)->getText();
+			);// $parser->parse($lenswikitext, $lenstitle, new ParserOptions(), true, true)->getText();
 
 			$lenssrc = "var ex_lens = '" . str_replace(
 					"\n",

--- a/formats/array/SRF_Hash.php
+++ b/formats/array/SRF_Hash.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * Query format for arrays with features for Extensions 'Arrays' and 'HashTables'
  *
@@ -46,9 +48,9 @@ class SRFHash extends SRFArray {
 		}
 		if ( $version !== null && version_compare( $version, '0.999', '>=' ) ) {
 			// Version 1.0+, doesn't use $wgHashTables anymore
-			global $wgParser;
 			/** ToDo: is there a way to get the actual parser which has started the query? */
-			ExtHashTables::get( $wgParser )->createHash( $hashId, $hash );
+			$parser = MediaWikiServices::getInstance()->getParser();
+			ExtHashTables::get( $parser )->createHash( $hashId, $hash );
 		} elseif ( !isset( $wgHashTables ) ) {
 			// Hash extension is not installed in this wiki
 			return false;


### PR DESCRIPTION
Since the minimum MW version is already set to 1.31, we can remove some
ancient back-compat code, and we know that MediaWikiServices::getParser()
will always be available.

Bug: T160811
