### PR TITLE
Add {{#itemsubjectraw}} for furhter processing

### DIFF
--- a/src/Outline/README.md
+++ b/src/Outline/README.md
@@ -27,6 +27,7 @@ The `...-item` template will also provide additional information such as:
 
 - `#itemsection` section number of the item
 - `#itemsubject` the subject (aka page) of the item processed
+- `#itemsubjectraw` the raw page title which can be used for further processing
 - `#userparam` content provided by a user via the `#ask` `userparam` parameter
 
 Use `introtemplate` \ `outrotemplate` to display a template before or after the query results. These can only be used in combination with the `template` paramter 

--- a/src/Outline/TemplateBuilder.php
+++ b/src/Outline/TemplateBuilder.php
@@ -106,6 +106,8 @@ class TemplateBuilder {
 				$template .= $this->parameter( "#itemnumber", $itemnumber );
 				$template .= $this->parameter( "#userparam", $this->params['userparam'] );
 
+				$template .= $this->itemRaw($dv);
+
 				$template .= $this->itemText( $dv, $linker, $printRequest, $first_col );
 				$template .= $this->close();
 
@@ -139,6 +141,12 @@ class TemplateBuilder {
 		);
 
 		return $this->parameter( $printRequest->getLabel(), $text );
+	}
+
+	private function itemRaw( $dv ){
+		$rawText = $dv->getShortText( SMW_OUTPUT_WIKI );
+
+		return $this->parameter( "#itemsubjectraw", $rawText );
 	}
 
 	private function open( $v ) {


### PR DESCRIPTION
This PR addresses or contains:
- a new variable {{#itemsubjectraw}}

This PR includes:
- [ ] Update of README.md fo Outline format
- [ ] Update of TemplateBuilder.php

Currently the Outline format does support

1. linking of subject items (which automatically makes use of Display Title) or 
2. unlinked subject items, showing the Display Title

If you want to use the template format in Outline you might want to look up additional fields. For this, you have to use option 2. because linked items can not be used in "ask queries". Unfortunately, option 2. does only return the Display Title, not the page title.

To solve this, this PR introduces an additional template parameter #itemsubjectraw which can be used inside the item's template for further processing.
