### PR TITLE
Remove check for MediaWiki environment from settings file

### DIFF
--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -9,10 +9,6 @@
  * @author Daniel Werner < danweetz@web.de >
  */
 
-if ( !defined( 'MEDIAWIKI' ) ) {
-  die( "This file is part of the Semantic Result Formats extension. It is not a valid entry point.\n" );
-}
-
 // The formats you want to be able to use.
 // See the INSTALL file or
 // http://www.semantic-mediawiki.org/wiki/Semantic_Result_Formats#Installation


### PR DESCRIPTION
Currently, SemanticResultsFormats autoloads its setup file via Composer's autoloader and exits if it does not detect a MediaWiki environment. This prevents developers from executing tools also installed via composer such as the `phpunit` binary, or `phpcs`/`phpcbf`/`phan` etc., as SemanticResultFormat will immediately exit the process. As a fix, remove the environment check; this is also consistent with how Semantic MediaWiki itself behaves since SemanticMediaWiki/SemanticMediaWiki#1732 and SemanticMediaWiki/Mermaid#47.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

