### PR TITLE
Remove and replace usages of Skin::makeVariablesScript()

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -44,7 +44,7 @@ final class SRFUtils {
 		];
 
 		$requireHeadItem =  [ 'srf.options' => $options ];
-		SMWOutputs::requireHeadItem( 'srf.options', SRFUtils::makeVariablesScript( $requireHeadItem, false ) );
+		SMWOutputs::requireHeadItem( 'srf.options', self::makeVariablesScript( $requireHeadItem, false ) );
 	}
 
 	/**

--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -44,7 +44,7 @@ final class SRFUtils {
 		];
 
 		$requireHeadItem =  [ 'srf.options' => $options ];
-		SMWOutputs::requireHeadItem( 'srf.options', Skin::makeVariablesScript( $requireHeadItem, false ) );
+		SMWOutputs::requireHeadItem( 'srf.options', SRFUtils::makeVariablesScript( $requireHeadItem, false ) );
 	}
 
 	/**
@@ -69,6 +69,21 @@ final class SRFUtils {
 		$link->setParameter( '' , 'class' );
 		$link->setParameter( '' , 'searchlabel' );
 		return $link->getText( SMW_OUTPUT_HTML, $linker );
+	}
+
+	/**
+	 * @since 3.2.0
+	 *
+	 * @param array $data
+	 *
+	 * @param string|null|bool $nonce
+	 *
+	 * @return string|WrappedString HTML
+	 */
+	public static function makeVariablesScript( $data, $nonce = null ) {
+		$script = ResourceLoader::makeConfigSetScript( $data );
+
+		return ResourceLoader::makeInlineScript( $script, $nonce );
 	}
 
 }

--- a/formats/boilerplate/SRF_Boilerplate.php
+++ b/formats/boilerplate/SRF_Boilerplate.php
@@ -235,7 +235,7 @@ class SRFBoilerplate extends SMWResultPrinter {
 		// Assign the ID to make a data instance readly available and distinguishable
 		// from other content within the same page
 		$requireHeadItem = [ $ID => FormatJson::encode( $data ) ];
-		SMWOutputs::requireHeadItem( $ID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $ID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// Add resource definitions that has been registered with SRF_Resource.php
 		// Resource definitions contain scripts, styles, messages etc.

--- a/formats/d3/SRF_D3Chart.php
+++ b/formats/d3/SRF_D3Chart.php
@@ -62,7 +62,7 @@ class SRFD3Chart extends SMWAggregatablePrinter {
 
 		// Encoding
 		$requireHeadItem = [ $d3chartID => FormatJson::encode( $d3data ) ];
-		SMWOutputs::requireHeadItem( $d3chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $d3chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// RL module
 		$resource = 'ext.srf.d3.chart.' . $this->params['charttype'];

--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -201,7 +201,7 @@ class SRFDygraphs extends SMWResultPrinter {
 
 		// Array encoding and output
 		$requireHeadItem = [ $chartID => FormatJson::encode( $chartData ) ];
-		SMWOutputs::requireHeadItem( $chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		SMWOutputs::requireResource( 'ext.srf.dygraphs' );
 

--- a/formats/jqplot/SRF_jqPlotChart.php
+++ b/formats/jqplot/SRF_jqPlotChart.php
@@ -59,7 +59,7 @@ class SRFjqPlotChart extends SRFjqPlot {
 
 		// Encode data objects
 		$requireHeadItem = [ $chartID => FormatJson::encode( $dataObject ) ];
-		SMWOutputs::requireHeadItem( $chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// Processing placeholder
 		$processing = SRFUtils::htmlProcessingElement( $this->isHTML );

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -328,7 +328,7 @@ class SRFjqPlotSeries extends SMWResultPrinter {
 
 		// Encoding
 		$requireHeadItem = [ $chartID => FormatJson::encode( $data ) ];
-		SMWOutputs::requireHeadItem( $chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// Add RL resources
 		$this->addResources();

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -308,7 +308,7 @@ class MediaPlayer extends ResultPrinter {
 		];
 
 		$requireHeadItem = [ $ID => FormatJson::encode( $output ) ];
-		SMWOutputs::requireHeadItem( $ID, Skin::makeVariablesScript( $requireHeadItem, false ) );
+		SMWOutputs::requireHeadItem( $ID, SRFUtils::makeVariablesScript( $requireHeadItem, false ) );
 
 		SMWOutputs::requireResource( 'ext.jquery.jplayer.skin.' . $this->params['theme'] );
 		SMWOutputs::requireResource( 'ext.srf.formats.media' );

--- a/formats/sparkline/SRF_Sparkline.php
+++ b/formats/sparkline/SRF_Sparkline.php
@@ -48,7 +48,7 @@ class SRFSparkline extends SMWAggregatablePrinter {
 
 		// Encode data objects
 		$requireHeadItem = [ $chartID => FormatJson::encode( $dataObject ) ];
-		SMWOutputs::requireHeadItem( $chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// RL module
 		SMWOutputs::requireResource( 'ext.srf.sparkline' );

--- a/formats/timeseries/SRF_Timeseries.php
+++ b/formats/timeseries/SRF_Timeseries.php
@@ -155,7 +155,7 @@ class SRFTimeseries extends SMWResultPrinter {
 
 		// Array encoding and output
 		$requireHeadItem = [ $chartID => FormatJson::encode( $chartData ) ];
-		SMWOutputs::requireHeadItem( $chartID, Skin::makeVariablesScript( $requireHeadItem ) );
+		SMWOutputs::requireHeadItem( $chartID, SRFUtils::makeVariablesScript( $requireHeadItem ) );
 
 		// RL module
 		SMWOutputs::requireResource( 'ext.srf.timeseries.flot' );


### PR DESCRIPTION
The function Skin::makeVariablesScript() will be deprecated in MediaWiki 1.36. Since it's used in a lot of places in this codebase, I reimplemented it in SRF utils class, and the rest is just minimal changes to move references from the MediaWiki Skin class to the location of the new function.


This PR is made in reference to: #
https://phabricator.wikimedia.org/T257995


This PR includes:
- [ ] Update of RELEASE-NOTES.md 
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
