### PR TITLE
Gallery: show default if there isn't results

### DIFF
--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -180,6 +180,13 @@ class Gallery extends ResultPrinter {
 			$html .= $this->getLink( $results, SMW_OUTPUT_HTML )->getText( SMW_OUTPUT_HTML, $this->mLinker );
 		}
 
+		// If available and no results, return default message
+
+		if ( $results == '' && $this->params[ 'default' ] !== '' ) {
+			$html = $this->params[ 'default' ];
+		}
+
+
 		return [ $html, 'nowiki' => true, 'isHTML' => true ];
 	}
 


### PR DESCRIPTION
This PR is made in reference to: #396

This PR addresses or contains:
- Currently the `default` parameter is being ignored with the gallery format. I tried to address it checking if `$results` is empty and if the default parameter has been set.

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #396 

This small addition works in my private wiki without errors. although I don't include a test in the commit added. I am not a PHP expert and it is my first contribution to SRF, so let me know of any possible error or improvement.