### PR TITLE
Extend Gallery format with property "captiontemplate" to wrap image c…

### DIFF
--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -330,6 +330,15 @@ class Gallery extends ResultPrinter {
 				$imgCaption = $ig->mParser->recursiveTagParse( $imgCaption );
 			}
 		}
+
+		if ( $this->params['captiontemplate'] !== '' ) {
+			$templateCode = "{{" . $this->params['captiontemplate'] .
+				"|imageraw=".$imgTitle->getPrefixedText()."|imagecaption=$imgCaption|imageredirect=$imgRedirect}}";
+
+			$imgCaption = $ig->mParser->recursiveTagParse( $templateCode );
+
+		}
+
 		// Use image alt as helper for either text
 		$imgAlt = $this->params['redirects'] === '' ? $imgCaption : ( $imgRedirect !== '' ? $imgRedirect : '' );
 		$ig->add( $imgTitle, $imgCaption, $imgAlt );
@@ -483,6 +492,12 @@ class Gallery extends ResultPrinter {
 			'type' => 'string',
 			'default' => '',
 			'message' => 'srf_paramdesc_captionproperty'
+		];
+
+		$params['captiontemplate'] = [
+			'type' => 'string',
+			'default' => '',
+			'message' => 'srf-paramdesc-captiontemplate'
 		];
 
 		$params['imageproperty'] = [

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -145,6 +145,7 @@
 	"srf_paramdesc_heights": "Die Höhe der Bilder",
 	"srf_paramdesc_autocaptions": "Den Dateinamen als Beschreibung verwenden, sofern keine angegeben wurde",
 	"srf_paramdesc_fileextensions": "Sofern der Dateiname als Beschreibung verwendet wird, ebenso die Dateierweiterung anzeigen",
+	"srf-paramdesc-captiontemplate": "Eine Vorlage, die zum Formatieren der Bildunterschriften in der Galerie verwendet wird. Sie bietet named args wie 'imageraw', 'imagecaption' und 'imageredirect'.",
 	"srf_paramdesc_captionproperty": "Der Name des Attributs auf abgefragten Seiten, der als Beschreibung verwendet werden soll",
 	"srf_paramdesc_imageproperty": "Der Name des Attributs auf abgefragten Seiten, das auf das zu verwendende Bild hinweist. Sofern festgelegt, werden die abgefragten Seiten selbst, nicht als Bild angezeigt.",
 	"srf-paramdesc-redirects": "Der Name des semantischen Attributs, welches das Ziel der Weiterleitung enthält",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -138,6 +138,7 @@
 	"srf_paramdesc_autocaptions": "Use filename as caption when none is provided",
 	"srf_paramdesc_fileextensions": "When using the filename as caption, also display the file extension",
 	"srf_paramdesc_captionproperty": "The name of a semantic property present on the queried pages to be used as caption",
+	"srf-paramdesc-captiontemplate": "A template used to format the gallery image captions. It provides named args like 'imageraw', 'imagecaption' and 'imageredirect'",
 	"srf_paramdesc_imageproperty": "Name of a semantic property on the queried pages that points to images to use. When set, the queried pages themselves will not be displayed as images",
 	"srf-paramdesc-redirects": "The name of a semantic property present on the queried pages which contain the redirect target",
 	"srf-paramdesc-navigation": "Layout navigation control",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -155,6 +155,7 @@
 	"srf_paramdesc_autocaptions": "{{doc-paramdesc|autocaptions}}",
 	"srf_paramdesc_fileextensions": "{{doc-paramdesc|fileextensions}}",
 	"srf_paramdesc_captionproperty": "{{doc-paramdesc|captionproperty}}",
+	"srf-paramdesc-captiontemplate": "{{doc-paramdesc|captiontemplate}}",
 	"srf_paramdesc_imageproperty": "{{doc-paramdesc|imageproperty}}",
 	"srf-paramdesc-redirects": "{{doc-paramdesc|redirects}}",
 	"srf-paramdesc-navigation": "{{doc-paramdesc|navigation}}",

--- a/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"namespace": "NS_FILE",
-			"page": "Gallery01.png",
+			"page": "Gallery02.png",
 			"contents": {
 				"upload": {
 					"file" : "/../Fixtures/image-upload-480.png",
@@ -34,8 +34,8 @@
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"srf-gallery\" data-redirect-type=\"_wpg\">",
-					"<div class=\"thumb\" style=\"width: 150px;\"><div style=\"margin:15px auto;\"><a href=\".*File:Gallery01.png\" class=\"image\">",
-					"<div class=\"imageraw\">File:Gallery01.png</div>"
+					"<div class=\"thumb\" style=\"width: 150px;\"><div style=\"margin:15px auto;\"><a href=\".*File:Gallery02.png\" class=\"image\">",
+					"<div class=\"imageraw\">File:Gallery02.png</div>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
@@ -1,0 +1,66 @@
+{
+	"description": "Test `format=gallery` with file upload and captiontemplate",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_FILE",
+			"page": "Gallery01.png",
+			"contents": {
+				"upload": {
+					"file" : "/../Fixtures/image-upload-480.png",
+					"text" : "[[Has file::{{FULLPAGENAME}}]] [[Has caption::123]]"
+				}
+			}
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "CTemplate",
+			"contents": "<div class=\"imageraw\">{{{imageraw|}}}</div>"
+		},
+		{
+			"page": "Example/Gallery-02/Q.2",
+			"contents": "{{#ask: [[Has caption::123]] |?Has file |format=gallery |captiontemplate=CTemplate |captionproperty=Has file |limit=1 }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 (imageraw)",
+			"subject": "Example/Gallery-02/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"srf-gallery\" data-redirect-type=\"_wpg\">",
+					"<div class=\"thumb\" style=\"width: 150px;\"><div style=\"margin:15px auto;\"><a href=\".*File:Gallery01.png\" class=\"image\">",
+					"<div class=\"imageraw\">File:Gallery01.png</div>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgEnableUploads": true,
+		"wgFileExtensions": [
+			"png"
+		],
+		"wgDefaultUserOptions": {
+			"thumbsize": 5
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		],
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"NS_FILE": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Add new property 'captiontemplate' to gallery format.
Using **named args** inside template 

The caption template will also provide additional information such as:

* `#imageraw` raw page title which can be used for further processing
* `#imagecaption` value of a semantic property present on the queried pages to be used as caption
* `#imageredirect` value of **"|redirects="** property

This PR is made in reference to: #376

