### PR TITLE
Makes sure the axis labels are passed to the bubble chart

### DIFF
--- a/formats/jqplot/resources/ext.srf.jqplot.chart.bubble.js
+++ b/formats/jqplot/resources/ext.srf.jqplot.chart.bubble.js
@@ -71,6 +71,10 @@
 			title: data.parameters.charttitle,
 			seriesColors: data.parameters.seriescolors ? data.parameters.seriescolors : ( data.parameters.colorscheme === null ? null : colorscheme[data.parameters.colorscheme][9] ),
 			grid: data.parameters.grid,
+			axes: {
+                                xaxis: data.parameters.labelaxislabel ? { label: data.parameters.labelaxislabel } : {},
+                                yaxis: data.parameters.numbersaxislabel ? { label: data.parameters.numbersaxislabel } : {}
+                        },
 			seriesDefaults: {
 				renderer: data.renderer === 'bubble' ? $.jqplot.BubbleRenderer : $.jqplot.PieRenderer,
 				shadow: data.parameters.theme !== 'simple',

--- a/formats/jqplot/resources/ext.srf.jqplot.chart.bubble.js
+++ b/formats/jqplot/resources/ext.srf.jqplot.chart.bubble.js
@@ -72,9 +72,9 @@
 			seriesColors: data.parameters.seriescolors ? data.parameters.seriescolors : ( data.parameters.colorscheme === null ? null : colorscheme[data.parameters.colorscheme][9] ),
 			grid: data.parameters.grid,
 			axes: {
-                                xaxis: data.parameters.labelaxislabel ? { label: data.parameters.labelaxislabel } : {},
-                                yaxis: data.parameters.numbersaxislabel ? { label: data.parameters.numbersaxislabel } : {}
-                        },
+				xaxis: data.parameters.labelaxislabel ? { label: data.parameters.labelaxislabel } : { },
+				yaxis: data.parameters.numbersaxislabel ? { label: data.parameters.numbersaxislabel } : { }
+			},
 			seriesDefaults: {
 				renderer: data.renderer === 'bubble' ? $.jqplot.BubbleRenderer : $.jqplot.PieRenderer,
 				shadow: data.parameters.theme !== 'simple',


### PR DESCRIPTION
Makes sure the labels are passed to the bubble chart aswel.

This PR addresses or contains:
- bubble chart axis labels fixes

This PR includes:
- [x] Update of ext.srf.jqplot.chart.buble.js