### PR TITLE
Remove the deprecated $wgParser from src/Graph/GraphPrinter.php

### DIFF
--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -148,7 +148,8 @@ class GraphPrinter extends ResultPrinter {
 		$graphFormatter->buildGraph( $this->nodes );
 
 		// Calls graphvizParserHook function from MediaWiki GraphViz extension
-		$result = $GLOBALS['wgParser']->recursiveTagParse( "<graphviz>" . $graphFormatter->getGraph
+		$parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
+		$result = $parser->recursiveTagParse( "<graphviz>" . $graphFormatter->getGraph
 				() . "</graphviz>" );
 
 		// append legend


### PR DESCRIPTION
Use \MediaWiki\MediaWikiServices::getInstance()->getParser() instead.

Fixes #662.
