### PR TITLE
Update ext.srf.filtered.value-filter.less

### DIFF
--- a/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
+++ b/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
@@ -70,6 +70,6 @@
 	}
 
 	.select2-search__field {
-		width: 100% !important;
+		width: 100%;
 	}
 }


### PR DESCRIPTION
fix search field placeholder truncated

currently, the placeholder text gets truncated in search_field filters. It looks like this.
![grafik](https://user-images.githubusercontent.com/4318745/134014218-12cadebf-2fdc-4c65-81f7-0bf90c9d2de5.png)

If I remove the `!important`, it seems to work. Have not experienced any side effects yet. Maybe someone can look at this to confirm it is working?
