### PR TITLE
Escape double quotes in node names

### DIFF
--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -101,7 +101,7 @@ class GraphFormatter {
 			 *
 			 * @var \SRF\Graph\GraphNode $node
 			 */
-			$this->add( "\"" . $node->getID() . "\"" );
+			$this->add( "\"" . addslashes( $node->getID() ) . "\"" );
 
 			if ( $this->options->isGraphLink() ) {
 


### PR DESCRIPTION
Page titles can contain double quotes. dot requires them to be escaped,
otherwise, dot is broken.

Fixes #665.