### PR TITLE
Add a blank space after the last bullet in 'tree' format

### DIFF
--- a/formats/tree/TreeNodeVisitor.php
+++ b/formats/tree/TreeNodeVisitor.php
@@ -49,7 +49,7 @@ class TreeNodePrinter implements Visitor {
 			return '';
 		}
 
-		$textForNode = str_repeat( ( $this->configuration['format'] === 'oltree' ) ? '#' : '*', $this->depth );
+		$textForNode = str_repeat( ( $this->configuration['format'] === 'oltree' ) ? '#' : '*', $this->depth ) . ' ';
 
 		if ( $this->configuration['template'] === '' ) {
 			// build simple list


### PR DESCRIPTION
This PR is made in reference to: #672

Tree format needs a blank space after the bullet.
Expected:

* node1
** node11

Actual:

*node1
**node11

Reason: after this change, {{#ask:...|format=tree}} can be safely wrapped with

{{#tag:plantuml|
@startmindmap
{{#ask:...|format=tree}}
@endmindmap
}}

as is.

if External Data or some other extension provides the tag <plantuml>.

Now the output of {{#ask:...|format=tree}} has to be processed
with a regular expression to inject the needed spaces.

Example: https://traditio.wiki/Template:MindMap.

Fixes #672