### PR TITLE
First attempt to run tests for SMW 4 and MW 1.36/1.37

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,17 +18,17 @@ jobs:
           - mediawiki_version: '1.35'
             semantic_mediawiki_version: 3.2.3
             mermaid_version: 3.0.1
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.35'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.36'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master
-            coverage: true
+            coverage: false
             experimental: false
           - mediawiki_version: '1.37'
             semantic_mediawiki_version: dev-master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
             mermaid_version: dev-master
             coverage: false
             experimental: true
+          - mediawiki_version: '1.37'
+            semantic_mediawiki_version: dev-master
+            mermaid_version: dev-master
+            coverage: false
+            experimental: true
 
     container:
       image: gesinn/docker-mediawiki:${{ matrix.mediawiki_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,18 +23,18 @@ jobs:
           - mediawiki_version: '1.35'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master
-            coverage: false
-            experimental: true
+            coverage: true
+            experimental: false
           - mediawiki_version: '1.36'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master
-            coverage: false
-            experimental: true
+            coverage: true
+            experimental: false
           - mediawiki_version: '1.37'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master
-            coverage: false
-            experimental: true
+            coverage: true
+            experimental: false
 
     container:
       image: gesinn/docker-mediawiki:${{ matrix.mediawiki_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,11 @@ jobs:
             mermaid_version: 3.0.1
             coverage: true
             experimental: false
+          - mediawiki_version: '1.35'
+            semantic_mediawiki_version: dev-master
+            mermaid_version: dev-master
+            coverage: false
+            experimental: true
           - mediawiki_version: '1.36'
             semantic_mediawiki_version: dev-master
             mermaid_version: dev-master

--- a/SemanticResultFormats.hooks.php
+++ b/SemanticResultFormats.hooks.php
@@ -60,61 +60,6 @@ final class SRFHooks {
 	}
 
 	/**
-	 * Add new JavaScript/QUnit testing modules
-	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ResourceLoaderTestModules
-	 *
-	 * @since: 1.9
-	 *
-	 * @param  array $testModules array of JavaScript testing modules
-	 * @param  ResourceLoader $resourceLoader object
-	 *
-	 * @return boolean
-	 */
-	public static function registerQUnitTests( array &$testModules, ResourceLoader &$resourceLoader ) {
-		$testModules['qunit']['ext.srf.tests'] = [
-			'scripts' => [
-				// Base
-				'tests/qunit/ext.srf.test.js',
-				'tests/qunit/ext.srf.util.test.js',
-
-				// Formats
-				'tests/qunit/formats/ext.srf.formats.eventcalendar.tests.js',
-				'tests/qunit/formats/ext.srf.formats.datatables.test.js',
-				'tests/qunit/formats/ext.srf.formats.filtered.test.js',
-				'tests/qunit/formats/ext.srf.formats.gallery.test.js',
-				'tests/qunit/formats/ext.srf.formats.media.test.js',
-				'tests/qunit/formats/ext.srf.formats.tagcloud.test.js',
-
-				// Widgets
-				'tests/qunit/widgets/ext.srf.widgets.eventcalendar.tests.js',
-				'tests/qunit/widgets/ext.srf.widgets.optionslist.test.js',
-				'tests/qunit/widgets/ext.srf.widgets.panel.test.js',
-				'tests/qunit/widgets/ext.srf.widgets.parameters.test.js'
-
-			],
-			'dependencies' => [
-				'ext.srf',
-				'ext.srf.util',
-				'ext.srf.eventcalendar',
-				'ext.srf.datatables',
-				'ext.srf.widgets',
-				'ext.srf.gallery.overlay',
-				'ext.srf.gallery.carousel',
-				'ext.srf.gallery.slideshow',
-				'ext.srf.gallery.redirect',
-				'ext.srf.formats.media',
-				'ext.srf.formats.tagcloud',
-				'ext.srf.filtered.value-filter.select',
-			],
-			'position' => 'top',
-			'localBasePath' => __DIR__,
-			'remoteExtPath' => 'SemanticResultFormats',
-		];
-
-		return true;
-	}
-
-	/**
 	 * Adds a link to Admin Links page.
 	 *
 	 * @since 1.7

--- a/SemanticResultFormats.php
+++ b/SemanticResultFormats.php
@@ -60,7 +60,6 @@ class SemanticResultFormats {
 		$GLOBALS['wgHooks']['ParserFirstCallInit'][] = 'SRFParserFunctions::registerFunctions';
 		$GLOBALS['wgHooks']['UnitTestsList'][] = 'SRFHooks::registerUnitTests';
 
-		$GLOBALS['wgHooks']['ResourceLoaderTestModules'][] = 'SRFHooks::registerQUnitTests';
 		$GLOBALS['wgHooks']['ResourceLoaderGetConfigVars'][] = 'SRFHooks::onResourceLoaderGetConfigVars';
 
 		// Format hooks

--- a/extension.json
+++ b/extension.json
@@ -28,6 +28,38 @@
 	"ExtensionFunctions": [
 		"SemanticResultFormats::onExtensionFunction"
 	],
+	"QUnitTestModule": {
+		"localBasePath": "",
+		"remoteExtPath": "SemanticResultFormats",
+		"scripts": [
+			"tests/qunit/ext.srf.test.js",
+			"tests/qunit/ext.srf.util.test.js",
+			"tests/qunit/formats/ext.srf.formats.datatables.test.js",
+			"tests/qunit/formats/ext.srf.formats.eventcalendar.tests.js",
+			"tests/qunit/formats/ext.srf.formats.filtered.test.js",
+			"tests/qunit/formats/ext.srf.formats.gallery.test.js",
+			"tests/qunit/formats/ext.srf.formats.media.test.js",
+			"tests/qunit/formats/ext.srf.formats.tagcloud.test.js",
+			"tests/qunit/widgets/ext.srf.widgets.eventcalendar.tests.js",
+			"tests/qunit/widgets/ext.srf.widgets.optionslist.test.js",
+			"tests/qunit/widgets/ext.srf.widgets.panel.test.js",
+			"tests/qunit/widgets/ext.srf.widgets.parameters.test.js"
+		],
+		"dependencies": [
+			"ext.srf",
+			"ext.srf.util",
+			"ext.srf.eventcalendar",
+			"ext.srf.datatables",
+			"ext.srf.widgets",
+			"ext.srf.gallery.overlay",
+			"ext.srf.gallery.carousel",
+			"ext.srf.gallery.slideshow",
+			"ext.srf.gallery.redirect",
+			"ext.srf.formats.media",
+			"ext.srf.formats.tagcloud",
+			"ext.srf.filtered.value-filter.select"
+		]
+	},
 	"load_composer_autoloader":true,
 	"manifest_version": 2
 }

--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -11,6 +11,7 @@ namespace SRF\Filtered;
 
 use Exception;
 use Html;
+use MediaWiki\MediaWikiServices;
 use SMW\Message;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryLinker;
@@ -99,7 +100,7 @@ class Filtered extends ResultPrinter {
 	public function getParser() {
 
 		if ( $this->parser === null ) {
-			$this->setParser( $GLOBALS['wgParser'] );
+			$this->setParser( MediaWikiServices::getInstance()->getParser() );
 		}
 
 		return $this->parser;

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -3,6 +3,7 @@
 namespace SRF;
 
 use Html;
+use MediaWiki\MediaWikiServices;
 use SMW\ResultPrinter;
 use SMWDataItem;
 use SMWOutputs;
@@ -79,7 +80,7 @@ class Gallery extends ResultPrinter {
 		// No need for a special page to use the parser but for the "normal" page
 		// view we have to ensure caption text is parsed correctly through the parser
 		if ( !$this->isSpecialPage() ) {
-			$ig->setParser( $GLOBALS['wgParser'] );
+			$ig->setParser( MediaWikiServices::getInstance()->getParser() );
 		}
 
 		$html = '';

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -67,10 +67,12 @@ class ResourceFormatter {
 	public static function encode( $id, $data ) {
 		ResourceManager::requireHeadItem(
 			$id,
-			\Skin::makeVariablesScript(
-				[
-					$id => json_encode( $data )
-				],
+			\ResourceLoader::makeInlineScript(
+				\ResourceLoader::makeConfigSetScript(
+					[
+						$id => json_encode( $data )
+					]
+				),
 				false
 			)
 		);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,7 @@ if ( !defined( 'SMW_PHPUNIT_FIRST_COLUMN_WIDTH' ) ) {
 
 print sprintf( "\n%-{$width}s%s\n", "Semantic Result Formats: ", SRF_VERSION );
 
-$autoLoader = require SMW_PHPUNIT_AUTOLOADER_FILE;
+$autoloader = require SMW_PHPUNIT_AUTOLOADER_FILE;
 $autoloader->addPsr4( 'SRF\\Tests\\', __DIR__ . '/phpunit' );
 $autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );
 $autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/../../SemanticMediaWiki/tests/phpunit' );

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests\Integration;
 
+use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**
@@ -14,6 +15,8 @@ use SMW\Tests\Utils\UtilityFactory;
  * @author mwjames
  */
 class I18nJsonFileIntegrityTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	/**
 	 * @dataProvider i18nFileProvider

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -1,5 +1,7 @@
 <?php
 namespace SRF\Tests\Integration\JSONScript;
+
+use ExtensionRegistry;
 use SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest as SMWJsonTestCaseScriptRunnerTest;
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests#write-integration-tests-using-json-script
@@ -44,13 +46,13 @@ class JsonTestCaseScriptRunnerTest extends SMWJsonTestCaseScriptRunnerTest {
 	}
 	public function checkMermaidDependency( $val, &$reason ) {
 
-		if ( !defined( 'MERMAID_VERSION' ) ) {
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Mermaid' ) ) {
 			$reason = "Dependency: Mermaid as requirement is not available!";
 			return false;
 		}
 
 		list( $compare, $requiredVersion ) = explode( ' ', $val );
-		$version = MERMAID_VERSION;
+		$version = ExtensionRegistry::getInstance()->getAllThings()['Mermaid']['version'];
 
 		if ( !version_compare( $version, $requiredVersion, $compare ) ) {
 			$reason = "Dependency: Required version of Mermaid($requiredVersion $compare $version) is not available!";

--- a/tests/phpunit/Unit/Formats/GalleryTest.php
+++ b/tests/phpunit/Unit/Formats/GalleryTest.php
@@ -6,6 +6,7 @@ use SRF\Gallery;
 use TraditionalImageGallery;
 use Title;
 use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\PHPUnitCompat;
 
 /**
  * Tests for the SRF\Gallery class.
@@ -24,6 +25,8 @@ use SMW\Test\QueryPrinterRegistryTestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class GalleryTest extends QueryPrinterRegistryTestCase {
+
+	use PHPUnitCompat;
 
 	private $queryResult;
 	private $title;

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -2,6 +2,9 @@
 
 namespace SRF\Test;
 
+use ExtensionRegistry;
+use MediaWiki\MediaWikiServices;
+use Parser;
 use SMW\Test\QueryPrinterRegistryTestCase;
 use SMW\Tests\Utils\Mock\CoreMockObjectRepository;
 use SMW\Tests\Utils\Mock\MockObjectBuilder;
@@ -35,12 +38,12 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 	 * other tests in case this one fails in between.
 	 */
 	public static function setUpBeforeClass(): void {
-		self::$initial_parser = $GLOBALS['wgParser'];
+		self::$initial_parser = MediaWikiServices::getInstance()->getParser();
 		self::$initial_title = $GLOBALS['wgTitle'];
 	}
 
 	protected function tearDown(): void {
-		$GLOBALS['wgParser'] = self::$initial_parser;
+		$this->replaceParser( self::$initial_parser );
 		$GLOBALS['wgTitle'] = self::$initial_title;
 
 		parent::tearDown();
@@ -92,14 +95,14 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 
 		// Restore GLOBAL state to ensure that preceding tests do not use a
 		// mocked instance
-		$GLOBALS['wgParser'] = $this->parser;
+		$this->replaceParser( $this->parser );
 		$GLOBALS['wgTitle'] = $this->title;
 	}
 
 	protected function prepareGlobalState() {
 
 		// Store current state
-		$this->parser = $GLOBALS['wgParser'];
+		$this->parser = MediaWikiServices::getInstance()->getParser();
 		$this->title = $GLOBALS['wgTitle'];
 
 		$parserOutput = $this->getMockBuilder( '\ParserOutput' )
@@ -123,8 +126,28 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 			->getMock();
 
 		// Careful!!
-		$GLOBALS['wgParser'] = $parser;
+		$this->replaceParser( $parser );
 		$GLOBALS['wgTitle'] = $title;
+	}
+
+	/**
+	 * Replaces the global Parser service.
+	 *
+	 * @param Parser $parser
+	 */
+	protected function replaceParser( Parser $parser ) {
+		// Direct access to the wgParser global was removed in SMW 4.0.0.
+		if ( ExtensionRegistry::getInstance()->isLoaded( 'SemanticMediaWiki', '<4.0.0') ) {
+			$GLOBALS['wgParser'] = $parser;
+		} else {
+			MediaWikiServices::getInstance()->disableService( 'Parser' );
+			MediaWikiServices::getInstance()->redefineService(
+				'Parser',
+				function () use ( $parser ) {
+					return $parser;
+				}
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/Formats/ValueRankTest.php
+++ b/tests/phpunit/Unit/Formats/ValueRankTest.php
@@ -3,6 +3,7 @@
 namespace SRF\Tests\Unit\Formats;
 
 use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\PHPUnitCompat;
 use SRFValueRank;
 
 /**
@@ -22,6 +23,8 @@ use SRFValueRank;
  * @author Sebastian Schmid < sebastian.schmid@geinn.it >
  */
 class ValueRankTest extends QueryPrinterRegistryTestCase {
+
+	use PHPUnitCompat;
 
 	/**
 	 * @see QueryPrinterRegistryTestCase::getFormats

--- a/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests\Outline;
 
+use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\ListTreeBuilder;
 use SRF\Outline\OutlineTree;
 
@@ -15,6 +16,8 @@ use SRF\Outline\OutlineTree;
  * @author mwjames
  */
 class ListTreeBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests\Outline;
 
+use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\OutlineResultPrinter;
 
 /**
@@ -14,6 +15,8 @@ use SRF\Outline\OutlineResultPrinter;
  * @author mwjames
  */
 class OutlineResultPrinterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	private $queryResult;
 

--- a/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests\Outline;
 
+use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\TemplateBuilder;
 use SRF\Outline\OutlineTree;
 
@@ -15,6 +16,8 @@ use SRF\Outline\OutlineTree;
  * @author mwjames
  */
 class TemplateBuilderTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 

--- a/tests/phpunit/Unit/ResourceFormatterTest.php
+++ b/tests/phpunit/Unit/ResourceFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests;
 
+use SMW\Tests\PHPUnitCompat;
 use SRF\ResourceFormatter;
 
 /**
@@ -14,6 +15,8 @@ use SRF\ResourceFormatter;
  * @author mwjames
  */
 class ResourceFormatterTest extends \PHPUnit_Framework_TestCase {
+
+	use PHPUnitCompat;
 
 	public function testSession() {
 


### PR DESCRIPTION
This PR is made in reference to: #694 (only partially, because during test executions classes are not found).

With this PR the tests will at least attempt to run, but then fail due to missing classes.

When adding the following aliases to `tests\bootstrap.php` (which I doubt is the correct way to do it):
```
class_alias( '\SMW\Tests\QueryPrinterRegistryTestCase', '\SMW\Test\QueryPrinterRegistryTestCase' );
class_alias( '\SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest', '\SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest' );
class_alias( '\SMW\Query\ResultPrinters\ResultPrinter', '\SMW\ResultPrinter' );
class_alias( '\SMW\Query\ResultPrinters\FileExportPrinter', '\SMW\FileExportPrinter' );
```
Then the result looks like this:
![image](https://user-images.githubusercontent.com/1428594/147270915-9b38e663-0654-4639-87db-453b6cd5780e.png)
CI example: https://github.com/malberts/SemanticResultFormats/runs/4620365772?check_suite_focus=true#step:8:1889

It seems like SMW's aliases are not being loaded correctly in SRF. With the above the tests will work, but it obviously does not fix #694 which requires the aliases outside of the tests.
