### PR TITLE
Add some linting tools and fix one found problem

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
+		<exclude name="PSR12.Properties.ConstantVisibility.NotFound" />
+	</rule>
+	<rule ref="MediaWiki.NamingConventions.ValidGlobalName">
+		<properties>
+			<property name="allowedPrefixes" type="array" value="eg,wg" />
+		</properties>
+	</rule>
+	<file>.</file>
+	<exclude-pattern>/(vendor|conf)/</exclude-pattern>
+	<arg name="extensions" value="php"/>
+	<arg name="encoding" value="UTF-8"/>
+</ruleset>

--- a/DefaultSettings.php
+++ b/DefaultSettings.php
@@ -74,7 +74,7 @@ $GLOBALS['srfgFormats'] = [
 	// large number of incoming properties assigned to each selected entity
 	// @see Help:Incoming_format
 	// 'incoming',
-	
+
 	// Still in alpha:
 	// 'jitgraph', // Several issues need to be fixed before this can be enabled, most notably it does not work properly with the RL.
 
@@ -88,7 +88,7 @@ $GLOBALS['srfgFormats'] = [
 
 // Load hash format only if HashTables extension is initialised, otherwise 'Array' format is enough
 // FIXME: According to the INSTALL file only formats should be enabled, that "do not require further software to be installed (besides SMW)"
-if(	array_key_exists( 'ExtHashTables', $GLOBALS['wgAutoloadClasses'] ) && defined( 'ExtHashTables::VERSION' )
+if(	isset( $GLOBALS['wgAutoloadClasses']['ExtHashTables'] ) && defined( 'ExtHashTables::VERSION' )
 	&& version_compare( ExtHashTables::VERSION, '0.999', '>=' )
 	|| isset( $GLOBALS['wgHashTables'] ) // Version < 1.0 alpha
 ) {

--- a/composer.json
+++ b/composer.json
@@ -77,11 +77,31 @@
 		}
 	},
 	"config": {
-		"process-timeout": 0
+		"process-timeout": 0,
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	},
 	"scripts":{
 		"test": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpunit": "php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist",
-		"integration": "composer phpunit -- --testsuite=semantic-result-formats-integration"
+		"integration": "composer phpunit -- --testsuite=semantic-result-formats-integration",
+		"lint": [
+			"@parallel-lint",
+			"minus-x check .",
+			"@phpcs"
+		],
+		"fix": [
+			"minus-x fix .",
+			"phpcbf"
+		],
+		"phpcs": "phpcs -sp",
+		"parallel-lint": "parallel-lint . --exclude vendor --exclude node_modules --exclude conf"
+	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "38.0.0",
+		"mediawiki/minus-x": "1.1.1",
+		"php-parallel-lint/php-console-highlighter": "0.5.0",
+		"php-parallel-lint/php-parallel-lint": "1.3.1"
 	}
 }


### PR DESCRIPTION
Fixes #698 by using `isset()` instead of `array_key_exists()`.

-------

This PR is made in reference to: #698

This PR addresses or contains:
- phpcs configuration
- update to composer.json to support common MW development

This PR includes: