### PR TITLE
Remove unused dependency to `symfony/css-selector`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,8 +48,7 @@
 		"composer/installers": ">=1.0.1",
 		"mediawiki/semantic-media-wiki": "~3.0|~4.0",
 		"nicmart/tree": "^0.2.7",
-		"data-values/geo": "~4.0|~3.0|~2.0",
-		"symfony/css-selector": "^3.3"
+		"data-values/geo": "~4.0|~3.0|~2.0"
 	},
 	"suggest": {
 		"phpoffice/phpspreadsheet": "Required for 'format=spreadsheet'",


### PR DESCRIPTION
There is no code relying on this dependency.

This PR is made in reference to: #710

This PR includes:
- [ ] Update of RELEASE-NOTES.md
- [ ] Tests (unit/integration)
- [ ] CI build passed