### PR TITLE
Update ext.srf.slideshow.js

### DIFF
--- a/formats/slideshow/resources/ext.srf.slideshow.js
+++ b/formats/slideshow/resources/ext.srf.slideshow.js
@@ -440,7 +440,7 @@
 
 		if ( navControls ) {
 			var slideshow = this;
-			mw.loader.using( 'jquery.ui.slider', function (){
+			mw.loader.using( 'jquery.ui', function (){
 			var readout = $( '<div class="slideshow-nav-readout">' + 1 + '</div>' );
 			nav = $( '<div class="slideshow-nav" >' );
 


### PR DESCRIPTION
The slider navigation controls wouldn't load because the module jquery.ui.slider doesn't exist anymore. Instead, check for jquery.ui, the new megamodule that replaces jquery.ui.*. See here: https://www.mediawiki.org/wiki/ResourceLoader/Migration_guide_%28users%29