### PR TITLE
Update ext.srf.filtered.value-filter.less

### DIFF
--- a/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
+++ b/formats/filtered/resources/css/ext.srf.filtered.value-filter.less
@@ -69,7 +69,4 @@
 		}
 	}
 
-	.select2-search__field {
-		width: 100% !important;
-	}
 }


### PR DESCRIPTION
Longer input placeholder text is cut off when .select2-search__field has width: 100% !important; The solution is to simply delete this styling, then nothing is cut off.