### PR TITLE
Use addMethods instead of onlyMethods when mocking stdClass

### DIFF
--- a/tests/phpunit/Unit/Formats/GalleryTest.php
+++ b/tests/phpunit/Unit/Formats/GalleryTest.php
@@ -82,7 +82,7 @@ class GalleryTest extends QueryPrinterRegistryTestCase {
 
 		$widget = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$widget->expects( $this->any() )
@@ -95,7 +95,7 @@ class GalleryTest extends QueryPrinterRegistryTestCase {
 
 		$intro = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$intro->expects( $this->any() )
@@ -108,7 +108,7 @@ class GalleryTest extends QueryPrinterRegistryTestCase {
 
 		$outro = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$outro->expects( $this->any() )

--- a/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
@@ -57,7 +57,7 @@ class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
 		// IParam is an empty interface !!! so we use stdClass
 		$outlineproperties = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$outlineproperties->expects( $this->any() )
@@ -70,7 +70,7 @@ class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$template = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$template->expects( $this->any() )
@@ -83,7 +83,7 @@ class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$introtemplate = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$introtemplate->expects( $this->any() )
@@ -96,7 +96,7 @@ class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$outrotemplate = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'getName', 'getValue' ] )
+			->addMethods( [ 'getName', 'getValue' ] )
 			->getMock();
 
 		$outrotemplate->expects( $this->any() )


### PR DESCRIPTION
[Relevant doc for PHPUnit](https://phpunit.readthedocs.io/en/9.5/test-doubles.html) : `addMethods()` is used when the method does not exist (which is the case here) and `onlyMethods()` when the method exists. This fixes the 2 tests marked as 'warning'.