### PR TITLE
Reactivate 12 skipped tests on PHP 7.4

### DIFF
--- a/tests/phpunit/Unit/BibTex/BibTexFileExportPrinterTest.php
+++ b/tests/phpunit/Unit/BibTex/BibTexFileExportPrinterTest.php
@@ -30,12 +30,6 @@ class BibTexFileExportPrinterTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider filenameProvider
 	 */
 	public function testGetFileName( $filename, $searchlabel, $expected ) {
-		if ( version_compare( phpversion(), '7.4', '>=' ) ) {
-			// ResultPrinterReflector creates notices on PHP 7.4+
-			$this->markTestSkipped();
-			return;
-		}
-
 		$parameters = [
 			'filename' => $filename,
 			'searchlabel' => $searchlabel

--- a/tests/phpunit/Unit/vCard/vCardFileExportPrinterTest.php
+++ b/tests/phpunit/Unit/vCard/vCardFileExportPrinterTest.php
@@ -22,12 +22,6 @@ class vCardFileExportPrinterTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		if ( version_compare( phpversion(), '7.4', '>=' ) ) {
-			// ResultPrinterReflector creates notices on PHP 7.4+
-			$this->markTestSkipped();
-			return;
-		}
-
 		$this->resultPrinterReflector = new ResultPrinterReflector();
 
 		$this->queryResult = $this->getMockBuilder( '\SMWQueryResult' )


### PR DESCRIPTION
This was deactivated in 670487bd3214 but it works now (at least when tested locally on MW 1.35 + SMW master + SRF master). I guess the version of PHPUnit changed and/or the tests in SMW were improved.