### PR TITLE
Handle unusual printout order and property chains in 'graph' format

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -357,5 +357,6 @@
 	"srf-error-gantt-sortkey" : "The '''sortkey''' you have choosen is not supported",
 	"srf-error-gantt-mermaid-not-installed": "Mermaid Extension needs to be installed.",
 	"srf-printername-gantt": "Gantt",
-	"srf-paramdesc-nodelabel": "Use a graph node label. Allowed values: displaytitle."
+	"srf-paramdesc-nodelabel": "Use a graph node label. Allowed values: displaytitle.",
+	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -373,5 +373,6 @@
 	"srf-error-gantt-sortkey": "This is an error message.",
 	"srf-error-gantt-mermaid-not-installed": "This is an error message.",
 	"srf-printername-gantt": "{{doc-smwformat|gantt}}",
-	"srf-paramdesc-nodelabel": "{{doc-paramdesc|nodelabel}}\n{{doc-important|Do not translate the possible parameters: \"displaytitle\".}}"
+	"srf-paramdesc-nodelabel": "{{doc-paramdesc|nodelabel}}\n{{doc-important|Do not translate the possible parameters: \"displaytitle\".}}",
+	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -348,5 +348,5 @@
 	"srf-paramdesc-gantt-leftpadding": "Ширина заголовка секции",
 	"srf-error-gantt-mermaid-not-installed": "Расширение Mermaid должно быть установлено.",
 	"srf-printername-gantt": "Диаграмма Ганта",
-	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
+	"srf-paramdesc-graphfields": "Отображатаь свойста не типа «Страница» внутри вершин графа, а не в виде его рёбер."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -347,5 +347,6 @@
 	"srf-paramdesc-gantt-barheight": "Высота панелей задач",
 	"srf-paramdesc-gantt-leftpadding": "Ширина заголовка секции",
 	"srf-error-gantt-mermaid-not-installed": "Расширение Mermaid должно быть установлено.",
-	"srf-printername-gantt": "Диаграмма Ганта"
+	"srf-printername-gantt": "Диаграмма Ганта",
+	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -348,5 +348,5 @@
 	"srf-paramdesc-gantt-leftpadding": "Ширина заголовка секции",
 	"srf-error-gantt-mermaid-not-installed": "Расширение Mermaid должно быть установлено.",
 	"srf-printername-gantt": "Диаграмма Ганта",
-	"srf-paramdesc-graphfields": "Отображатаь свойста не типа «Страница» внутри вершин графа, а не в виде его рёбер."
+	"srf-paramdesc-graphfields": "Отображать свойста не типа «Страница» внутри вершин графа, а не в виде его рёбер."
 }

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -86,7 +86,7 @@ class GraphFormatter {
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
 			$instance = $this;
-			$nodeLabel = $node->getLabel();
+			$nodeLabel = htmlspecialchars( $node->getLabel() );
 
 			// take "displaytitle" as node-label if it is set
 			if ( $this->options->getNodeLabel() === GraphPrinter::NODELABEL_DISPLAYTITLE ) {

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -261,18 +261,12 @@ class GraphFormatter {
 	 * @return string
 	 */
 	public function getWordWrappedText( $text, $charLimit ) {
-		return implode( $this->lineSeparator, array_reduce(
-			preg_split( '/\s+/', $text ),
-			static function ( array $wrapped, $word ) use ( $charLimit ) {
-				$last = count( $wrapped ) - 1;
-				if ( $last < 0 || mb_strlen( $wrapped[$last] ) + 1 + mb_strlen( $word ) > $charLimit ) {
-					$wrapped[] = $word;
-				} else {
-					$wrapped[$last] .= ' ' . $word;
-				}
-				return $wrapped;
-			},
-			[]
-		) );
+		preg_match_all(
+			'/\S{' . $charLimit . ',}|\S.{1,' . ( $charLimit - 1 ) . '}(?=\s+|$)/u',
+			$text,
+			$matches,
+			PREG_PATTERN_ORDER
+		);
+		return implode( $this->lineSeparator, $matches[0] );
 	}
 }

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -56,7 +56,8 @@ class GraphFormatter {
 	}
 
 	/*
-	* Creates the DOT (graph description language) which can be processed by the Diagrams or GraphViz extension
+	* Creates the DOT (graph description language),
+	*  which can be processed by the Diagrams, GraphViz or External Data extension
 	*
 	* @see https://www.graphviz.org/ for documentation about the DOT language
 	* @since 3.2
@@ -65,7 +66,8 @@ class GraphFormatter {
 	*/
 	public function buildGraph( $nodes ) {
 		global $wgVersion;
-		$this->add( "digraph " . $this->options->getGraphName() . " {" );
+
+		$this->add( 'digraph "' . $this->options->getGraphName() . '" {' );
 
 		// set fontsize and fontname of graph, nodes and edges
 		$this->add( "graph [fontsize=" . $this->options->getGraphFontSize() . ", fontname=\"Verdana\"]\n" );
@@ -105,14 +107,12 @@ class GraphFormatter {
 					?: strtr( $this->getWordWrappedText( $node->getID(), $this->options->getWordWrapLimit() ),
 							  [ '\n' => '<br/>' ] );
 				$nodeTooltip = $nodeLabel ?: $node->getID();
-
 				// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
 				// and formatting is a little different from the GraphViz extension
 				if ( version_compare( $wgVersion, '1.33', '>=' ) &&
 					\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
-					$nodeTooltip = str_replace( "<br />", "", $nodeTooltip );
+					$nodeTooltip = str_replace( '<br />', '', $nodeTooltip );
 				}
-
 				// Label in HTML form enclosed with <>.
 				$nodeLabel = "<\n" . '<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">' . "\n"
 							. '<tr><td colspan="2" href="' . $nodeLinkURL . '">' . $label . "</td></tr><hr/>\n"
@@ -122,8 +122,8 @@ class GraphFormatter {
 									: 'left';
 								return '<tr><td align="left" href="[[Property:' . $field['page'] . ']]">'
 									. $field['name'] . '</td>'
-									. '<td align="' . $alignment . '">' .
-										$instance->getWordWrappedText(
+									. '<td align="' . $alignment . '">'
+										. $instance->getWordWrappedText(
 											$field['value'],
 											$instance->options->getWordWrapLimit()
 										)
@@ -251,35 +251,21 @@ class GraphFormatter {
 	 * @return string
 	 */
 	public static function getWordWrappedText( $text, $charLimit ) {
-		$charLimit = max( [ $charLimit, 1 ] );
-		$segments = [];
-
-		while ( strlen( $text ) > $charLimit ) {
-			// Find the last space in the allowed range.
-			$splitPosition = strrpos( substr( $text, 0, $charLimit ), ' ' );
-
-			if ( $splitPosition === false ) {
-				// If there is no space (lond word), find the next space.
-				$splitPosition = strpos( $text, ' ' );
-
-				if ( $splitPosition === false ) {
-					// If there are no spaces, everything goes on one line.
-					$splitPosition = strlen( $text ) - 1;
-				}
+		$words = preg_split( '/\s+/', $text );
+		$lines = [];
+		$line = -1; // will advance to 0 on the first loop.
+		foreach( $words as $word ) {
+			if ( $line < 0 || $length + 1 + mb_strlen( $word ) > $charLimit ) {
+				// First word, or the line is getting too long. Begin a new line.
+				$lines[++$line] = []; // add new line.
+				$length = -1; // reset current line's length. No space before the first word is needed.
 			}
-
-			$segments[] = substr( $text, 0, $splitPosition + 1 );
-			$text = substr( $text, $splitPosition + 1 );
+			$lines[$line][] = $word;
+			$length += 1 + mb_strlen( $word ); // 1 is for the space between the words.
 		}
-
-		$segments[] = $text;
-
-		global $wgVersion;
-		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
-		// and formatting is a little different from the GraphViz extension
-		$implodeChar = version_compare( $wgVersion, '1.33', '>=' ) &&
-			\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ? '<br />' : '\n';
-
-		return implode( $implodeChar, $segments );
+		// Glue lines by newline and words in lines by space.
+		return implode( PHP_EOL, array_map( static function ( array $words ) {
+			return implode( ' ', $words );
+		}, $lines ) );
 	}
 }

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -263,8 +263,15 @@ class GraphFormatter {
 			$lines[$line][] = $word;
 			$length += 1 + mb_strlen( $word ); // 1 is for the space between the words.
 		}
+		global $wgVersion;
+
+		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
+		// and formatting is a little different from the GraphViz extension
+		$implodeChar = version_compare( $wgVersion, '1.33', '>=' ) &&
+		\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ? '<br />' : PHP_EOL;
+
 		// Glue lines by newline and words in lines by space.
-		return implode( PHP_EOL, array_map( static function ( array $words ) {
+		return implode( $implodeChar, array_map( static function ( array $words ) {
 			return implode( ' ', $words );
 		}, $lines ) );
 	}

--- a/src/Graph/GraphOptions.php
+++ b/src/Graph/GraphOptions.php
@@ -27,6 +27,8 @@ class GraphOptions {
 	private $showGraphLabel;
 	private $showGraphColor;
 	private $showGraphLegend;
+	/** @var bool Show non-Page properties as fields within nodes rather than edges. */
+	private $showGraphFields;
 
 	public function __construct( $options ) {
 		$this->graphName = trim( $options['graphname'] );
@@ -42,6 +44,7 @@ class GraphOptions {
 		$this->showGraphLabel = trim( $options['graphlabel'] );
 		$this->showGraphColor = trim( $options['graphcolor'] );
 		$this->showGraphLegend = trim( $options['graphlegend'] );
+		$this->showGraphFields = trim( $options['graphfields'] );
 	}
 
 	public function getGraphName(): string {
@@ -94,5 +97,9 @@ class GraphOptions {
 
 	public function isGraphLegend(): bool {
 		return $this->showGraphLegend;
+	}
+
+	public function showGraphFields(): bool {
+		return $this->showGraphFields;
 	}
 }

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -174,37 +174,49 @@ class GraphPrinter extends ResultPrinter {
 	 *
 	 */
 	protected function processResultRow( array /* of SMWResultArray */ $row ) {
+		$node = null;
+		$fields = [];
+		$parents = [];
 		// loop through all row fields
-		foreach ( $row as $i => $resultArray ) {
-
-			// loop through all values of a multivalue field
-			while ( ( /* SMWWikiPageValue */
-				$object = $resultArray->getNextDataValue() ) !== false ) {
-
+		foreach ( $row as $resultArray ) {
+			// Loop through all values of a multivalue field.
+			while ( ( /* SMWWikiPageValue */ $object = $resultArray->getNextDataValue() ) !== false ) {
 				$type = $object->getTypeID();
 				if ( in_array( $type, [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ] ) ) {
-					// This is a page. A new node and an edge have to be created.
-					// create SRF\GraphNode for column 0
-					if ( $i === 0 ) {
+					// This is a property of the type 'Page'.
+					if ( !$node && !$object->getProperty() ) {
+						// The graph node for the current record has not been created,
+						// and this is the printout '?'. So, create it now.
 						$node = new GraphNode( $object->getShortWikiText() );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
-						$this->nodes[] = $node;
 					} else {
-						$node->addParentNode(
-							$resultArray->getPrintRequest()->getLabel(),
-							$object->getShortWikiText()
-						);
+						// Remember a parent node to add.
+						$parents[] = [
+							'predicate' => $resultArray->getPrintRequest()->getLabel(),
+							'object' => $object->getShortWikiText()
+						];
 					}
 				} else {
-					// A non-page property.
-					$node->addField(
-						$resultArray->getPrintRequest()->getOutputFormat(),
-						$object->getShortWikiText(),
-						$type,
-						$resultArray->getPrintRequest()->getLabel()
-					);
+					// A non-Page property, no edge for it. Remember the field to add at the end of the row.
+					$fields[] = [
+						'name' => $resultArray->getPrintRequest()->getOutputFormat(),
+						'value' => $object->getShortWikiText(),
+						'type' => $type,
+						'page' => $resultArray->getPrintRequest()->getLabel()
+					];
 				}
 			}
+		}
+		// Add the node, if any, its parent nodes and fields for non-Page properties to the current edge.
+		if ( $node ) {
+			foreach( $parents as $parent ) {
+				$node->addParentNode( $parent['predicate'], $parent['object'] );
+				// @TODO: add explicit nodes with hyperlinks to every parent node not added as '?', but only once.
+			}
+			foreach ( $fields as $field ) {
+				$node->addField( $field['name'], $field['value'], $field['type'], $field['page'] );
+			}
+			$this->nodes[] = $node;
 		}
 	}
 

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -28,6 +28,8 @@ class GraphPrinter extends ResultPrinter {
 	// @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4273
 	// Implement `ResultPrinterDependency` once SMW 3.1 becomes mandatory
 
+	/** @const string[] PAGETYPES SMW types that represent SMW pages and should always be displayed as nodes. */
+	private const PAGETYPES = [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ];
 	const NODELABEL_DISPLAYTITLE = 'displaytitle';
 	public static $NODE_LABELS = [
 		self::NODELABEL_DISPLAYTITLE,
@@ -337,6 +339,13 @@ class GraphPrinter extends ResultPrinter {
 			'default' => '',
 			'message' => 'srf-paramdesc-nodelabel',
 			'values' => self::$NODE_LABELS,
+		];
+		
+		$params['graphfields'] = [
+			'default' => false,
+			'message' => 'srf-paramdesc-graph-fields',
+			'manipluatedefault' => false,
+			'type' => 'boolean'
 		];
 
 		$params['graphfields'] = [

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -111,11 +111,16 @@ class GraphPrinter extends ResultPrinter {
 	 * {@inheritDoc}
 	 */
 	public function hasMissingDependency() {
+		$registry = \ExtensionRegistry::getInstance();
 		return (
-			!\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ||
+			// <graphviz> can be provided by Diagrams.
+			!$registry->isLoaded( 'Diagrams' ) ||
 			!class_exists( 'GraphViz' ) && !class_exists( '\\MediaWiki\\Extension\\GraphViz\\GraphViz' )
-			// <graphviz can also be added by External Data.
-		) && !in_array( 'graphviz', MediaWikiServices::getInstance()->getParser()->getTags() );
+		) && !(
+			// <graphviz can also be added by External Data in Tag emulation mode.
+			$registry->isLoaded( 'External Data' ) &&
+			in_array( 'graphviz', MediaWikiServices::getInstance()->getParser()->getTags() )
+		);
 	}
 
 	/**
@@ -129,7 +134,8 @@ class GraphPrinter extends ResultPrinter {
 			[
 				'class' => 'smw-callout smw-callout-error'
 			],
-			'The SRF Graph printer requires the GraphViz extension to be installed.'
+			'The SRF Graph printer requires the GraphViz or Diagrams or External Data ' .
+			'(with <graphviz> tag defined in Tag emulation mode ) extension to be installed.'
 		);
 	}
 

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -156,7 +156,7 @@ class GraphPrinter extends ResultPrinter {
 			$this->processResultRow( $row );
 		}
 
-		// use GraphFormater to build the graph
+		// use GraphFormatter to build the graph
 		$graphFormatter = new GraphFormatter( $this->options );
 		$graphFormatter->buildGraph( $this->nodes );
 

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -182,8 +182,11 @@ class GraphPrinter extends ResultPrinter {
 			// Loop through all values of a multivalue field.
 			while ( ( /* SMWWikiPageValue */ $object = $resultArray->getNextDataValue() ) !== false ) {
 				$type = $object->getTypeID();
-				if ( in_array( $type, [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ] ) ) {
-					// This is a property of the type 'Page'.
+				if (
+					in_array( $type, [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ] ) ||
+					!$this->options->showGraphFields()
+				) {
+					// This is a property of the type 'Page' OR all properties are shown as edges.
 					if ( !$node && !$object->getProperty() ) {
 						// The graph node for the current record has not been created,
 						// and this is the printout '?'. So, create it now.

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -28,8 +28,6 @@ class GraphPrinter extends ResultPrinter {
 	// @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/4273
 	// Implement `ResultPrinterDependency` once SMW 3.1 becomes mandatory
 
-	/** @const string[] PAGETYPES SMW types that represent SMW pages and should always be displayed as nodes. */
-	private const PAGETYPES = [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ];
 	const NODELABEL_DISPLAYTITLE = 'displaytitle';
 	public static $NODE_LABELS = [
 		self::NODELABEL_DISPLAYTITLE,
@@ -158,7 +156,7 @@ class GraphPrinter extends ResultPrinter {
 			$this->processResultRow( $row );
 		}
 
-		// use GraphFormatter to build the graph
+		// use GraphFormater to build the graph
 		$graphFormatter = new GraphFormatter( $this->options );
 		$graphFormatter->buildGraph( $this->nodes );
 
@@ -340,7 +338,7 @@ class GraphPrinter extends ResultPrinter {
 			'message' => 'srf-paramdesc-nodelabel',
 			'values' => self::$NODE_LABELS,
 		];
-		
+
 		$params['graphfields'] = [
 			'default' => false,
 			'message' => 'srf-paramdesc-graph-fields',

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -134,8 +134,8 @@ class GraphPrinter extends ResultPrinter {
 			[
 				'class' => 'smw-callout smw-callout-error'
 			],
-			'The SRF Graph printer requires the GraphViz or Diagrams or External Data ' .
-			'(with <graphviz> tag defined in Tag emulation mode ) extension to be installed.'
+			'The SRF Graph printer requires the GraphViz, Diagrams or External Data ' .
+			'(with &lt;graphviz&gt; tag defined in Tag emulation mode) extension to be installed.'
 		);
 	}
 
@@ -170,7 +170,7 @@ class GraphPrinter extends ResultPrinter {
 		} else {
 			// Calls graphvizParserHook function from MediaWiki GraphViz or External Data extension
 			$parser = MediaWikiServices::getInstance()->getParser();
-			$result = $parser->recursiveTagParse( "<graphviz>" . $graphFormatter->getGraph() . "</graphviz>" );
+			$result = $parser->recursiveTagParse( '<graphviz>' . $graphFormatter->getGraph() . '</graphviz>' );
 		}
 
 		// Append legend
@@ -207,7 +207,6 @@ class GraphPrinter extends ResultPrinter {
 			// Loop through all values of a multivalue field.
 			while ( ( /* SMWWikiPageValue */ $object = $result_array->getNextDataValue() ) !== false ) {
 				if ( $show_as_edge ) {
-					// All properties are shown as edges anyway OR this is a property of the type 'Page'.
 					if ( !$node && !$object->getProperty() ) {
 						// The graph node for the current record has not been created,
 						// and this is the printout '?'. So, create it now.
@@ -224,10 +223,10 @@ class GraphPrinter extends ResultPrinter {
 					// A non-Page property and 'graphfields' is set,
 					// so display it as a field after the row has been processed.
 					$fields[] = [
-						'name' => $request->getOutputFormat(),
+						'name' => $request->getLabel(),
 						'value' => $object->getShortWikiText(),
 						'type' => $type,
-						'page' => $request->getLabel()
+						'page' => $request->getCanonicalLabel()
 					];
 				}
 			}

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -156,15 +156,16 @@ class GraphPrinter extends ResultPrinter {
 			$this->processResultRow( $row );
 		}
 
-		// use GraphFormater to build the graph
+		// use GraphFormatter to build the graph
 		$graphFormatter = new GraphFormatter( $this->options );
 		$graphFormatter->buildGraph( $this->nodes );
 
-		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
+		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams or External Data extension
 		// and formatting is a little different from the GraphViz extension
 		global $wgVersion;
 		if ( version_compare( $wgVersion, '1.33', '>=' ) &&
 			\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
+			// Using Diagrams extension.
 			$result = "<graphviz>{$graphFormatter->getGraph()}</graphviz>";
 		} else {
 			// Calls graphvizParserHook function from MediaWiki GraphViz or External Data extension

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -42,6 +42,7 @@ class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 			'graphlabel' => true,
 			'graphcolor' => true,
 			'graphlegend' => true,
+			'graphfields' => false
 		];
 
 		$this->options = new GraphOptions( $params );

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -16,79 +16,26 @@ use SRF\Graph\GraphOptions;
  */
 class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 
-	/*
-	* @see https://www.semantic-mediawiki.org/wiki/Help:Graph_format
-	*/
-	private $options;
-
-	private $graphFormatter;
-
-	private $nodes = [];
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$params = [
-			'graphname' => 'Unit Test',
-			'graphsize' => '100',
-			'graphfontsize' => 10,
-			'nodeshape' => 'rect',
-			'nodelabel' => 'displaytitle',
-			'arrowdirection' => 'LR',
-			'arrowhead' => 'diamond',
-			'wordwraplimit' => 20,
-			'relation' => 'parent',
-			'graphlink' => true,
-			'graphlabel' => true,
-			'graphcolor' => true,
-			'graphlegend' => true,
-			'graphfields' => false
-		];
-
-		$this->options = new GraphOptions( $params );
-
-		$this->graphFormatter = new GraphFormatter( $this->options );
-
-		$node1 = new GraphNode( 'Team:Alpha' );
-		$node1->setLabel( "Alpha" );
-		$node1->addParentNode( "Casted", "Person:Alexander Gesinn" );
-		$this->nodes[] = $node1;
-
-		$node2 = new GraphNode( 'Team:Beta' );
-		$node2->setLabel( "Beta" );
-		$node2->addParentNode( "Casted", "Person:Sebastian Schmid" );
-		$node2->addParentNode( "Casted", "Person:Alexander Gesinn" );
-		$node2->addParentNode( "Part of Team ", "Team:Alpha" );
-		$this->nodes[] = $node2;
-
-		$this->graphFormatter->buildGraph( $this->nodes );
-	}
-
-	public function testCanConstruct() {
-		$this->assertInstanceOf( GraphFormatter::class, new GraphFormatter( $this->options ) );
-	}
-
-	public function testGetWordWrappedText() {
-		$text = 'Lorem ipsum dolor sit amet';
-		$expected =  \ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' )
-		 	? 'Lorem <br />ipsum <br />dolor sit <br />amet'
-			: 'Lorem \nipsum \ndolor sit \namet';
-
-		$this->assertEquals( GraphFormatter::getWordWrappedText( $text, 10 ), $expected );
-	}
-
-	public function testGetGraphLegend() {
-		$expected = "<div class=\"graphlegend\">" .
-			"<div class=\"graphlegenditem\" style=\"color: black\">black: Casted</div>" .
-			"<div class=\"graphlegenditem\" style=\"color: red\">red: Part of Team </div>" .
-			"</div>";
-
-		$this->assertEquals( $this->graphFormatter->getGraphLegend(), $expected );
-	}
-
-	public function testBuildGraph() {
-		$expected = <<<'DOT'
-digraph Unit Test {graph [fontsize=10, fontname="Verdana"]
+	/** @var array $cases An array of test cases. */
+	private $cases = [
+		'Simple' => [
+			'params' => [ 'graphfields' => false ], // @see https://www.semantic-mediawiki.org/wiki/Help:Graph_format
+			'nodes' => [
+				[ 'name' => 'Team:Alpha', 'label' => 'Alpha', 'parents' => [
+					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ]
+				] ],
+				[ 'name' => 'Team:Beta', 'label' => 'Beta', 'parents' => [
+					[ 'predicate' => 'Casted', 'object' => 'Person:Sebastian Schmid' ],
+					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ],
+					[ 'predicate' => 'Part of Team', 'object' => 'Team:Alpha' ],
+				] ]
+			],
+			'legend' => '<div class="graphlegend">' .
+				'<div class="graphlegenditem" style="color: black">black: Casted</div>' .
+				'<div class="graphlegenditem" style="color: red">red: Part of Team</div>' .
+				'</div>',
+			'dot' => <<<'SIMPLE'
+digraph "Unit Test" {graph [fontsize=10, fontname="Verdana"]
 node [fontsize=10, fontname="Verdana"];
 edge [fontsize=10, fontname="Verdana"];
 size="100";node [shape=rect];rankdir=LR;
@@ -97,9 +44,195 @@ size="100";node [shape=rect];rankdir=LR;
 "Person:Alexander Gesinn" -> "Team:Alpha" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
 "Person:Sebastian Schmid" -> "Team:Beta" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
 "Person:Alexander Gesinn" -> "Team:Beta" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
-"Team:Alpha" -> "Team:Beta" [label="Part of Team ",fontcolor=red,arrowhead=diamond,color=red];
+"Team:Alpha" -> "Team:Beta" [label="Part of Team",fontcolor=red,arrowhead=diamond,color=red];
 }
-DOT;
-		$this->assertEquals( $this->graphFormatter->getGraph(), $expected );
+SIMPLE
+		],
+		'With fields' => [
+			'params' => [ 'graphfields' => true ], // @see https://www.semantic-mediawiki.org/wiki/Help:Graph_format
+			'nodes' => [
+				[ 'name' => 'Team:Alpha', 'label' => 'Alpha', 'parents' => [
+					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ]
+				], 'fields' => [
+					[ 'name' => 'Rated as', 'value' => 10, 'type' => '_num', 'page' => 'Rating' ]
+				] ],
+				[ 'name' => 'Team:Beta', 'label' => 'Beta', 'parents' => [
+					[ 'predicate' => 'Casted', 'object' => 'Person:Sebastian Schmid' ],
+					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ],
+					[ 'predicate' => 'Part of Team', 'object' => 'Team:Alpha' ],
+				], 'fields' => [
+					[ 'name' => 'Rated as', 'value' => 20, 'type' => '_num', 'page' => 'Rating' ]
+				] ]
+			],
+			'legend' => '<div class="graphlegend">' .
+				'<div class="graphlegenditem" style="color: black">black: Casted</div>' .
+				'<div class="graphlegenditem" style="color: red">red: Part of Team</div>' .
+				'</div>',
+			'dot' => <<<'FIELDS'
+digraph "Unit Test" {graph [fontsize=10, fontname="Verdana"]
+node [fontsize=10, fontname="Verdana"];
+edge [fontsize=10, fontname="Verdana"];
+size="100";node [shape=rect];rankdir=LR;
+"Team:Alpha" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Alpha]]">Alpha</td></tr><hr/>
+<tr><td align="left" href="[[Property:Rating]]">Rated as</td><td align="right">10</td></tr>
+</table>
+>, tooltip = "Alpha"];
+"Team:Beta" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Beta]]">Beta</td></tr><hr/>
+<tr><td align="left" href="[[Property:Rating]]">Rated as</td><td align="right">20</td></tr>
+</table>
+>, tooltip = "Beta"];
+"Person:Alexander Gesinn" -> "Team:Alpha" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
+"Person:Sebastian Schmid" -> "Team:Beta" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
+"Person:Alexander Gesinn" -> "Team:Beta" [label="Casted",fontcolor=black,arrowhead=diamond,color=black];
+"Team:Alpha" -> "Team:Beta" [label="Part of Team",fontcolor=red,arrowhead=diamond,color=red];
+}
+FIELDS
+		]
+
+	];
+
+	/** @const array BASE_PARAMS A non-changing subset of parameters. */
+	/** @see https://www.semantic-mediawiki.org/wiki/Help:Graph_format */
+	private const BASE_PARAMS = [
+		'graphname' => 'Unit Test',
+		'graphsize' => '100',
+		'graphfontsize' => 10,
+		'nodeshape' => 'rect',
+		'nodelabel' => 'displaytitle',
+		'arrowdirection' => 'LR',
+		'arrowhead' => 'diamond',
+		'wordwraplimit' => 20,
+		'relation' => 'parent',
+		'graphlink' => true,
+		'graphlabel' => true,
+		'graphcolor' => true,
+		'graphlegend' => true,
+	];
+
+	/**
+	 * Create a complete graph for the test case.
+	 * @var array $case
+	 * @return GraphFormatter
+	 */
+	private static function graph( array $case ): GraphFormatter {
+		$graph = new GraphFormatter( new GraphOptions( GraphFormatterTest::BASE_PARAMS + $case['params'] ) );
+		$nodes = [];
+		foreach ( $case['nodes'] as $node ) {
+			$graph_node = new GraphNode( $node['name'] );
+			$graph_node->setLabel( $node['label'] );
+			if ( isset( $node['parents'] ) ) {
+				foreach ( $node['parents'] as $parent ) {
+					$graph_node->addParentNode( $parent['predicate'], $parent['object'] );
+				}
+			}
+			if ( isset( $node['fields'] ) ) {
+				foreach ( $node['fields'] as $field ) {
+					$graph_node->addField( $field['name'], $field['value'], $field['type'], $field['page'] );
+				}
+			}
+			$nodes[] = $graph_node;
+		}
+		$graph->buildGraph( $nodes );
+		return $graph;
+	}
+
+	/**
+	 * @return array Test cases.
+	 */
+	public function provideCanConstruct(): array {
+		$cases = [];
+		foreach ( $this->cases as $name => $case ) {
+			$cases[$name] = [ self::BASE_PARAMS + $case['params'] ];
+		}
+		return $cases;
+	}
+
+	/**
+	 * @covers GraphFormatter::__construct()
+	 * @dataProvider provideCanConstruct
+	 * @param array $params
+	 * @return void
+	 */
+	public function testCanConstruct( array $params ) {
+		$this->assertInstanceOf( GraphFormatter::class, new GraphFormatter( new GraphOptions( $params ) ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provideGetWordWrappedText(): array {
+		return [
+			'Simple wrap' => [
+				'Lorem ipsum dolor sit amet',
+				<<<'WRAPPED0'
+Lorem
+ipsum
+dolor sit
+amet
+WRAPPED0
+			],
+			'Unwrappable' => [ 'Supercalifragilisticexpialidocious', 'Supercalifragilisticexpialidocious' ],
+			'One line' => [ 'One line', 'One line' ],
+			'Empty' => [ '', '' ]
+		];
+	}
+
+	/**
+	 * @covers GraphFormatter::getWordWrappedText()
+	 * @dataProvider provideGetWordWrappedText
+	 * @param string $unwrapped
+	 * @param string $wrapped
+	 * @return void
+	 */
+	public function testGetWordWrappedText( $unwrapped, $wrapped ) {
+		$this->assertEquals( $wrapped, GraphFormatter::getWordWrappedText( $unwrapped, 10 ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provideGetGraphLegend(): array {
+		$cases = [];
+		foreach ( $this->cases as $name => $case ) {
+			$cases[$name] = [ $case, $case['legend'] ];
+		}
+		return $cases;
+	}
+
+	/**
+	 * @covers GraphFormatter::getGraphLegend()
+	 * @dataProvider provideGetGraphLegend
+	 * @param array $params
+	 * @param string $expected The expected legend.
+	 * @return void
+	 */
+	public function testGetGraphLegend( array $params, $expected ) {
+		$this->assertEquals( $expected, self::graph( $params )->getGraphLegend() );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function provideBuildGraph(): array {
+		$cases = [];
+		foreach ( $this->cases as $name => $case ) {
+			$cases[$name] = [ $case, $case['dot'] ];
+		}
+		return $cases;
+	}
+
+	/**
+	 * @covers GraphFormatter::buildGraph()
+	 * @dataProvider provideBuildGraph
+	 * @param array $params
+	 * @param string $expected The expected DOT code.
+	 * @return void
+	 */
+	public function testBuildGraph( array $params, $expected ) {
+		$this->assertEquals( $expected, self::graph( $params )->getGraph() );
 	}
 }

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -92,7 +92,6 @@ size="100";node [shape=rect];rankdir=LR;
 }
 FIELDS
 		]
-
 	];
 
 	/** @const array BASE_PARAMS A non-changing subset of parameters. */
@@ -189,7 +188,10 @@ WRAPPED0
 	 * @return void
 	 */
 	public function testGetWordWrappedText( $unwrapped, $wrapped ) {
-		$this->assertEquals( $wrapped, GraphFormatter::getWordWrappedText( $unwrapped, 10 ) );
+		$formatter = new GraphFormatter(
+			new GraphOptions( GraphFormatterTest::BASE_PARAMS + ['graphfields' => false] )
+		);
+		$this->assertEquals( $wrapped, $formatter->getWordWrappedText( $unwrapped, 10 ) );
 	}
 
 	/**


### PR DESCRIPTION
Handle unusual printout order in 'graph' format, i.e., the one with main column absent or not the first printout.

Per @YOUR1: added 'graphfields' parameter (off by default) that switches non-page properties display to labels within nodes from edges.

Property chains are displayed as edges regardless of the type of the last link.

Unit tests for the 'graph' format rewritten and extended.

Bug: #742