### PR TITLE
Replacing unmaintained extension GraphViz with Diagrams

### DIFF
--- a/formats/graphviz/README
+++ b/formats/graphviz/README
@@ -5,7 +5,7 @@ query results.
 == Installation ==
 For these two formats to work you do not just need the Semantic MediaWiki
 and the Semantic Result Formats extension to be installed but also the
-GraphViz extension and the ImageMap extension. Moreover the GraphViz extension
+Diagrams extension and the ImageMap extension. Moreover the Diagrams extension
 requires the graphviz and mscgen packages to be installed on your server.
 
 The extensions mentioned are best installed using Composer. Please refer to

--- a/formats/graphviz/README
+++ b/formats/graphviz/README
@@ -5,8 +5,9 @@ query results.
 == Installation ==
 For these two formats to work you do not just need the Semantic MediaWiki
 and the Semantic Result Formats extension to be installed but also the
-Diagrams extension and the ImageMap extension. Moreover the Diagrams extension
-requires the graphviz and mscgen packages to be installed on your server.
+Diagrams (or GraphViz) extension and the ImageMap extension. Moreover
+the Diagrams or GraphViz extension requires the graphviz and mscgen
+packages to be installed on your server.
 
 The extensions mentioned are best installed using Composer. Please refer to
 the individual documentation on how to do this.

--- a/formats/graphviz/SRF_Process.php
+++ b/formats/graphviz/SRF_Process.php
@@ -200,8 +200,9 @@ class SRFProcess extends SMWResultPrinter {
 	 *
 	 */
 	protected function getResultText( SMWQueryResult $res, $outputmode ) {
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
-			wfWarn( 'The SRF Graph printer needs the Diagrams extension to be installed.' );
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) &&
+			!is_callable( 'renderGraphviz' ) ) {
+			wfWarn( 'The SRF Graph printer needs the Diagrams or GraphViz extension to be installed.' );
 			return '';
 		}
 

--- a/formats/graphviz/SRF_Process.php
+++ b/formats/graphviz/SRF_Process.php
@@ -200,10 +200,11 @@ class SRFProcess extends SMWResultPrinter {
 	 *
 	 */
 	protected function getResultText( SMWQueryResult $res, $outputmode ) {
-		if ( !is_callable( 'renderGraphviz' ) ) {
-			wfWarn( 'The SRF Graph printer needs the GraphViz extension to be installed.' );
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
+			wfWarn( 'The SRF Graph printer needs the Diagrams extension to be installed.' );
 			return '';
 		}
+
 
 		global $wgContLang; // content language object
 

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -56,9 +56,9 @@ class GraphFormatter {
 	}
 
 	/*
-	* Creates the DOT (graph description language) which can be processed by the graphviz lib
+	* Creates the DOT (graph description language) which can be processed by the Diagrams extension
 	*
-	* @see https://www.graphviz.org/
+	* @see https://www.graphviz.org/ for documentation about the DOT language
 	* @since 3.2
 	*
 	* @param SRF\Graph\GraphNodes[] $nodes
@@ -84,7 +84,7 @@ class GraphFormatter {
 
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
-
+			$instance = $this;
 			$nodeLabel = $node->getLabel();
 
 			// take "displaytitle" as node-label if it is set
@@ -104,16 +104,22 @@ class GraphFormatter {
 					?: strtr( $this->getWordWrappedText( $node->getID(), $this->options->getWordWrapLimit() ),
 							  [ '\n' => '<br/>' ] );
 				$nodeTooltip = $nodeLabel ?: $node->getID();
+				$nodeTooltip = str_replace( "<br />", "", $nodeTooltip );
 				// Label in HTML form enclosed with <>.
 				$nodeLabel = "<\n" . '<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">' . "\n"
 							. '<tr><td colspan="2" href="' . $nodeLinkURL . '">' . $label . "</td></tr><hr/>\n"
-							. implode( "\n", array_map( static function ( $field ) {
+							. implode( "\n", array_map( static function ( $field ) use ( $instance ) {
 								$alignment = in_array( $field['type'], [ '_num', '_qty', '_dat', '_tem' ] )
 									? 'right'
 									: 'left';
 								return '<tr><td align="left" href="[[Property:' . $field['page'] . ']]">'
 									. $field['name'] . '</td>'
-									. '<td align="' . $alignment . '">' . $field['value'] . '</td></tr>';
+									. '<td align="' . $alignment . '">' .
+										$instance->getWordWrappedText(
+											$field['value'],
+											$instance->options->getWordWrapLimit()
+										)
+									. '</td></tr>';
 							}, $fields ) ) . "\n</table>\n>";
 				$nodeLinkURL = null; // the value at the top is already hyperlinked.
 			} else {
@@ -260,6 +266,6 @@ class GraphFormatter {
 
 		$segments[] = $text;
 
-		return implode( '\n', $segments );
+		return implode( '<br />', $segments );
 	}
 }

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -69,7 +69,9 @@ class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testGetWordWrappedText() {
 		$text = 'Lorem ipsum dolor sit amet';
-		$expected = 'Lorem <br />ipsum <br />dolor sit <br />amet';
+		$expected =  \ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' )
+		 	? 'Lorem <br />ipsum <br />dolor sit <br />amet'
+			: 'Lorem \nipsum \ndolor sit \namet';
 
 		$this->assertEquals( GraphFormatter::getWordWrappedText( $text, 10 ), $expected );
 	}

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -69,7 +69,7 @@ class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testGetWordWrappedText() {
 		$text = 'Lorem ipsum dolor sit amet';
-		$expected = 'Lorem \nipsum \ndolor sit \namet';
+		$expected = 'Lorem <br />ipsum <br />dolor sit <br />amet';
 
 		$this->assertEquals( GraphFormatter::getWordWrappedText( $text, 10 ), $expected );
 	}


### PR DESCRIPTION
The [GraphViz](https://www.mediawiki.org/wiki/Extension:GraphViz) extension is unmaintained and not working with MW versions newer then 1.32. [Diagrams ](https://www.mediawiki.org/wiki/Extension:Diagrams) seems to do the same, and is working properly. We've tested it and came to the conclusion that Diagrams is a good replacement. 