### PR TITLE
GraphViz Added graphfields option

### DIFF
--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -100,7 +100,7 @@ class GraphFormatter {
 
 			// Display fields, if any.
 			$fields = $node->getFields();
-			if ( count( $node->getFields() ) > 0 ) {
+			if ( count( $fields ) > 0 && $this->options->showGraphFields() ) {
 				$label = $nodeLabel
 					?: strtr( $this->getWordWrappedText( $node->getID(), $this->options->getWordWrapLimit() ),
 							  [ '\n' => '<br/>' ] );

--- a/src/Graph/GraphOptions.php
+++ b/src/Graph/GraphOptions.php
@@ -28,6 +28,9 @@ class GraphOptions {
 	private $showGraphColor;
 	private $showGraphLegend;
 
+	/** @var bool */
+	private $showGraphFields;
+
 	public function __construct( $options ) {
 		$this->graphName = trim( $options['graphname'] );
 		$this->graphSize = trim( $options['graphsize'] );
@@ -42,6 +45,7 @@ class GraphOptions {
 		$this->showGraphLabel = trim( $options['graphlabel'] );
 		$this->showGraphColor = trim( $options['graphcolor'] );
 		$this->showGraphLegend = trim( $options['graphlegend'] );
+		$this->showGraphFields = trim( $options['graphfields'] );
 	}
 
 	public function getGraphName(): string {
@@ -94,5 +98,9 @@ class GraphOptions {
 
 	public function isGraphLegend(): bool {
 		return $this->showGraphLegend;
+	}
+
+	public function showGraphFields(): bool {
+		return $this->showGraphFields;
 	}
 }

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -42,6 +42,7 @@ class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 			'graphlabel' => true,
 			'graphcolor' => true,
 			'graphlegend' => true,
+			'graphfields' => false
 		];
 
 		$this->options = new GraphOptions( $params );


### PR DESCRIPTION
Reverting back changes from https://github.com/SemanticMediaWiki/SemanticResultFormats/commit/dcfd97fc12b153a6ea0d227acde1475079bc1990 to the original one since it breaks the functionality that was here in the first place.

Since I don't want to neglect the changes @alex-mashin made, I implemented a 'graphfields' option, so his fields feature are still visible and usable.

Graph without fields (old and default behaviour):
![Screenshot 2022-11-10 at 14 58 48](https://user-images.githubusercontent.com/3681016/201111056-40571a88-1b1f-4681-832b-43cd33d885f2.png)

Graph with fields (new option):
![Screenshot 2022-11-10 at 15 00 16](https://user-images.githubusercontent.com/3681016/201111345-5079e3f8-3c06-498f-9793-f173a9fbe5b0.png)

