### PR TITLE
Handle unusual printout order and property chains in 'graph' format

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -357,5 +357,6 @@
 	"srf-error-gantt-sortkey" : "The '''sortkey''' you have choosen is not supported",
 	"srf-error-gantt-mermaid-not-installed": "Mermaid Extension needs to be installed.",
 	"srf-printername-gantt": "Gantt",
-	"srf-paramdesc-nodelabel": "Use a graph node label. Allowed values: displaytitle."
+	"srf-paramdesc-nodelabel": "Use a graph node label. Allowed values: displaytitle.",
+	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -373,5 +373,6 @@
 	"srf-error-gantt-sortkey": "This is an error message.",
 	"srf-error-gantt-mermaid-not-installed": "This is an error message.",
 	"srf-printername-gantt": "{{doc-smwformat|gantt}}",
-	"srf-paramdesc-nodelabel": "{{doc-paramdesc|nodelabel}}\n{{doc-important|Do not translate the possible parameters: \"displaytitle\".}}"
+	"srf-paramdesc-nodelabel": "{{doc-paramdesc|nodelabel}}\n{{doc-important|Do not translate the possible parameters: \"displaytitle\".}}",
+	"srf-paramdesc-graphfields": "Display non-page property values within graph nodes rather than as edges."
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -347,5 +347,6 @@
 	"srf-paramdesc-gantt-barheight": "Высота панелей задач",
 	"srf-paramdesc-gantt-leftpadding": "Ширина заголовка секции",
 	"srf-error-gantt-mermaid-not-installed": "Расширение Mermaid должно быть установлено.",
-	"srf-printername-gantt": "Диаграмма Ганта"
+	"srf-printername-gantt": "Диаграмма Ганта",
+	"srf-paramdesc-graphfields": "Отображать свойста не типа «Страница» внутри вершин графа, а не в виде его рёбер."
 }

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -37,9 +37,19 @@ class GraphFormatter {
 	];
 	private $legendItem = [];
 	private $options;
+	/** @var string $lineSeparator Line separator for line wrapped long text. */
+	private $lineSeparator;
 
 	public function __construct( GraphOptions $options ) {
 		$this->options = $options;
+
+		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
+		// and formatting is a little different from the GraphViz extension
+		global $wgVersion;
+		$this->lineSeparator
+			= version_compare( $wgVersion, '1.33', '>=' ) && \ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' )
+			? '<br />'
+			: PHP_EOL;
 	}
 
 	public function getGraph() {
@@ -56,7 +66,8 @@ class GraphFormatter {
 	}
 
 	/*
-	* Creates the DOT (graph description language) which can be processed by the Diagrams or GraphViz extension
+	* Creates the DOT (graph description language),
+	*  which can be processed by the Diagrams, GraphViz or External Data extension
 	*
 	* @see https://www.graphviz.org/ for documentation about the DOT language
 	* @since 3.2
@@ -65,7 +76,8 @@ class GraphFormatter {
 	*/
 	public function buildGraph( $nodes ) {
 		global $wgVersion;
-		$this->add( "digraph " . $this->options->getGraphName() . " {" );
+
+		$this->add( 'digraph "' . $this->options->getGraphName() . '" {' );
 
 		// set fontsize and fontname of graph, nodes and edges
 		$this->add( "graph [fontsize=" . $this->options->getGraphFontSize() . ", fontname=\"Verdana\"]\n" );
@@ -86,7 +98,7 @@ class GraphFormatter {
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
 			$instance = $this;
-			$nodeLabel = $node->getLabel();
+			$nodeLabel = htmlspecialchars( $node->getLabel() );
 
 			// take "displaytitle" as node-label if it is set
 			if ( $this->options->getNodeLabel() === GraphPrinter::NODELABEL_DISPLAYTITLE ) {
@@ -100,19 +112,17 @@ class GraphFormatter {
 
 			// Display fields, if any.
 			$fields = $node->getFields();
-			if ( count( $node->getFields() ) > 0 ) {
+			if ( count( $fields ) > 0 ) {
 				$label = $nodeLabel
 					?: strtr( $this->getWordWrappedText( $node->getID(), $this->options->getWordWrapLimit() ),
 							  [ '\n' => '<br/>' ] );
 				$nodeTooltip = $nodeLabel ?: $node->getID();
-
 				// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
 				// and formatting is a little different from the GraphViz extension
 				if ( version_compare( $wgVersion, '1.33', '>=' ) &&
 					\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
-					$nodeTooltip = str_replace( "<br />", "", $nodeTooltip );
+					$nodeTooltip = str_replace( '<br />', '', $nodeTooltip );
 				}
-
 				// Label in HTML form enclosed with <>.
 				$nodeLabel = "<\n" . '<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">' . "\n"
 							. '<tr><td colspan="2" href="' . $nodeLinkURL . '">' . $label . "</td></tr><hr/>\n"
@@ -122,8 +132,8 @@ class GraphFormatter {
 									: 'left';
 								return '<tr><td align="left" href="[[Property:' . $field['page'] . ']]">'
 									. $field['name'] . '</td>'
-									. '<td align="' . $alignment . '">' .
-										$instance->getWordWrappedText(
+									. '<td align="' . $alignment . '">'
+										. $instance->getWordWrappedText(
 											$field['value'],
 											$instance->options->getWordWrapLimit()
 										)
@@ -250,36 +260,13 @@ class GraphFormatter {
 	 *
 	 * @return string
 	 */
-	public static function getWordWrappedText( $text, $charLimit ) {
-		$charLimit = max( [ $charLimit, 1 ] );
-		$segments = [];
-
-		while ( strlen( $text ) > $charLimit ) {
-			// Find the last space in the allowed range.
-			$splitPosition = strrpos( substr( $text, 0, $charLimit ), ' ' );
-
-			if ( $splitPosition === false ) {
-				// If there is no space (lond word), find the next space.
-				$splitPosition = strpos( $text, ' ' );
-
-				if ( $splitPosition === false ) {
-					// If there are no spaces, everything goes on one line.
-					$splitPosition = strlen( $text ) - 1;
-				}
-			}
-
-			$segments[] = substr( $text, 0, $splitPosition + 1 );
-			$text = substr( $text, $splitPosition + 1 );
-		}
-
-		$segments[] = $text;
-
-		global $wgVersion;
-		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
-		// and formatting is a little different from the GraphViz extension
-		$implodeChar = version_compare( $wgVersion, '1.33', '>=' ) &&
-			\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ? '<br />' : '\n';
-
-		return implode( $implodeChar, $segments );
+	public function getWordWrappedText( $text, $charLimit ) {
+		preg_match_all(
+			'/\S{' . $charLimit . ',}|\S.{1,' . ( $charLimit - 1 ) . '}(?=\s+|$)/u',
+			$text,
+			$matches,
+			PREG_PATTERN_ORDER
+		);
+		return implode( $this->lineSeparator, $matches[0] );
 	}
 }

--- a/src/Graph/GraphOptions.php
+++ b/src/Graph/GraphOptions.php
@@ -27,6 +27,8 @@ class GraphOptions {
 	private $showGraphLabel;
 	private $showGraphColor;
 	private $showGraphLegend;
+	/** @var bool Show non-Page properties as fields within nodes rather than edges. */
+	private $showGraphFields;
 
 	public function __construct( $options ) {
 		$this->graphName = trim( $options['graphname'] );
@@ -42,6 +44,7 @@ class GraphOptions {
 		$this->showGraphLabel = trim( $options['graphlabel'] );
 		$this->showGraphColor = trim( $options['graphcolor'] );
 		$this->showGraphLegend = trim( $options['graphlegend'] );
+		$this->showGraphFields = trim( $options['graphfields'] );
 	}
 
 	public function getGraphName(): string {
@@ -94,5 +97,9 @@ class GraphOptions {
 
 	public function isGraphLegend(): bool {
 		return $this->showGraphLegend;
+	}
+
+	public function showGraphFields(): bool {
+		return $this->showGraphFields;
 	}
 }

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -2,17 +2,18 @@
 
 namespace SRF\Graph;
 
-Use MediaWiki\MediaWikiServices;
 use Html;
+Use MediaWiki\MediaWikiServices;
+use SMW\Query\Result\ResultArray;
 use SMW\ResultPrinter;
 use SMWQueryResult;
+use SMW\Query\PrintRequest;
 
 /**
  * SMW result printer for graphs using graphViz.
  * In order to use this printer you need to have both
  * the graphViz library installed on your system and
- * have the graphViz or Diagrams MediaWiki extension
- * installed.
+ * have the graphViz, Diagrams or ExternalData MediaWiki extension installed.
  *
  * @file SRF_Graph.php
  * @ingroup SemanticResultFormats
@@ -31,6 +32,8 @@ class GraphPrinter extends ResultPrinter {
 	public static $NODE_LABELS = [
 		self::NODELABEL_DISPLAYTITLE,
 	];
+	/** @const string[] PAGETYPES SMW types that represent SMW pages and should always be displayed as nodes. */
+	private const PAGETYPES = [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ];
 
 	public static $NODE_SHAPES = [
 		'box',
@@ -85,6 +88,7 @@ class GraphPrinter extends ResultPrinter {
 		'vee',
 	];
 
+	/** @var GraphNode[] */
 	private $nodes = [];
 	private $options;
 
@@ -107,8 +111,16 @@ class GraphPrinter extends ResultPrinter {
 	 * {@inheritDoc}
 	 */
 	public function hasMissingDependency() {
-		return !\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' )
-			|| !class_exists( 'GraphViz' ) && !class_exists( '\\MediaWiki\\Extension\\GraphViz\\GraphViz' );
+		$registry = \ExtensionRegistry::getInstance();
+		return (
+			// <graphviz> can be provided by Diagrams.
+			!$registry->isLoaded( 'Diagrams' ) ||
+			!class_exists( 'GraphViz' ) && !class_exists( '\\MediaWiki\\Extension\\GraphViz\\GraphViz' )
+		) && !(
+			// <graphviz can also be added by External Data in Tag emulation mode.
+			$registry->isLoaded( 'External Data' ) &&
+			in_array( 'graphviz', MediaWikiServices::getInstance()->getParser()->getTags() )
+		);
 	}
 
 	/**
@@ -122,7 +134,8 @@ class GraphPrinter extends ResultPrinter {
 			[
 				'class' => 'smw-callout smw-callout-error'
 			],
-			'The SRF Graph printer requires the Diagrams or GraphViz extension to be installed.'
+			'The SRF Graph printer requires the GraphViz, Diagrams or External Data ' .
+			'(with &lt;graphviz&gt; tag defined in Tag emulation mode) extension to be installed.'
 		);
 	}
 
@@ -133,7 +146,10 @@ class GraphPrinter extends ResultPrinter {
 	 * @return string
 	 */
 	protected function getResultText( SMWQueryResult $res, $outputmode ) {
-		global $wgVersion;
+		// Remove this once SRF requires 3.1+
+		if ( $this->hasMissingDependency() ) {
+			return $this->getDependencyError();
+		}
 
 		// iterate query result and create SRF\GraphNodes
 		while ( $row = $res->getNext() ) {
@@ -144,17 +160,20 @@ class GraphPrinter extends ResultPrinter {
 		$graphFormatter = new GraphFormatter( $this->options );
 		$graphFormatter->buildGraph( $this->nodes );
 
-		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams extension
+		// GraphViz is not working for version >= 1.33, so we need to use the Diagrams or External Data extension
 		// and formatting is a little different from the GraphViz extension
+		global $wgVersion;
 		if ( version_compare( $wgVersion, '1.33', '>=' ) &&
 			\ExtensionRegistry::getInstance()->isLoaded( 'Diagrams' ) ) {
+			// Using Diagrams extension.
 			$result = "<graphviz>{$graphFormatter->getGraph()}</graphviz>";
 		} else {
-			// Calls graphvizParserHook function from MediaWiki GraphViz extension
+			// Calls graphvizParserHook function from MediaWiki GraphViz or External Data extension
 			$parser = MediaWikiServices::getInstance()->getParser();
-			$result = $parser->recursiveTagParse( "<graphviz>" . $graphFormatter->getGraph() . "</graphviz>" );
+			$result = $parser->recursiveTagParse( '<graphviz>' . $graphFormatter->getGraph() . '</graphviz>' );
 		}
 
+		// Append legend
 		$result .= $graphFormatter->getGraphLegend();
 
 		if ( $outputmode === SMW_OUTPUT_HTML ) {
@@ -162,7 +181,6 @@ class GraphPrinter extends ResultPrinter {
 		}
 
 		return MediaWikiServices::getInstance()->getParser()->recursiveTagParse( $result );
-
 	}
 
 	/**
@@ -170,41 +188,59 @@ class GraphPrinter extends ResultPrinter {
 	 *
 	 * @since 3.1
 	 *
-	 * @param array $row
+	 * @param ResultArray[] $row
 	 *
 	 */
-	protected function processResultRow( array /* of SMWResultArray */ $row ) {
+	protected function processResultRow( array $row ) {
+		$node = null;
+		$fields = [];
+		$parents = [];
 		// loop through all row fields
-		foreach ( $row as $i => $resultArray ) {
+		foreach ( $row as $result_array ) {
+			$request = $result_array->getPrintRequest();
+			$type = $request->getTypeID();
+			// Whether this printout should be shown as an edge.
+			$show_as_edge = !$this->options->showGraphFields() // no fields at all.
+				|| in_array( $type, self::PAGETYPES ) // property of the type 'Page'.
+				|| $request->isMode( PrintRequest::PRINT_CHAIN ); // property chain, treated like 'Page'.
 
-			// loop through all values of a multivalue field
-			while ( ( /* SMWWikiPageValue */
-				$object = $resultArray->getNextDataValue() ) !== false ) {
-
-				$type = $object->getTypeID();
-				if ( in_array( $type, [ '_wpg', '_wpp', '_wps', '_wpu', '__sup', '__sin', '__suc', '__con' ] ) ) {
-					// This is a page. A new node and an edge have to be created.
-					// create SRF\GraphNode for column 0
-					if ( $i === 0 ) {
+			// Loop through all values of a multivalue field.
+			while ( ( /* SMWWikiPageValue */ $object = $result_array->getNextDataValue() ) !== false ) {
+				if ( $show_as_edge ) {
+					if ( !$node && !$object->getProperty() ) {
+						// The graph node for the current record has not been created,
+						// and this is the printout '?'. So, create it now.
 						$node = new GraphNode( $object->getShortWikiText() );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
-						$this->nodes[] = $node;
 					} else {
-						$node->addParentNode(
-							$resultArray->getPrintRequest()->getLabel(),
-							$object->getShortWikiText()
-						);
+						// Remember a parent node to add after the row is processed.
+						$parents[] = [
+							'predicate' => $request->getLabel(),
+							'object' => $object->getShortWikiText()
+						];
 					}
 				} else {
-					// A non-page property.
-					$node->addField(
-						$resultArray->getPrintRequest()->getOutputFormat(),
-						$object->getShortWikiText(),
-						$type,
-						$resultArray->getPrintRequest()->getLabel()
-					);
+					// A non-Page property and 'graphfields' is set,
+					// so display it as a field after the row has been processed.
+					$fields[] = [
+						'name' => $request->getLabel(),
+						'value' => $object->getShortWikiText(),
+						'type' => $type,
+						'page' => $request->getCanonicalLabel()
+					];
 				}
 			}
+		}
+		// Add the node, if any, its parent nodes and fields for non-Page properties to the current edge.
+		if ( $node ) {
+			foreach( $parents as $parent ) {
+				$node->addParentNode( $parent['predicate'], $parent['object'] );
+				// @TODO: add explicit nodes with hyperlinks to every parent node not added as '?', but only once.
+			}
+			foreach ( $fields as $field ) {
+				$node->addField( $field['name'], $field['value'], $field['type'], $field['page'] );
+			}
+			$this->nodes[] = $node;
 		}
 	}
 
@@ -301,6 +337,20 @@ class GraphPrinter extends ResultPrinter {
 			'default' => '',
 			'message' => 'srf-paramdesc-nodelabel',
 			'values' => self::$NODE_LABELS,
+		];
+
+		$params['graphfields'] = [
+			'default' => false,
+			'message' => 'srf-paramdesc-graph-fields',
+			'manipluatedefault' => false,
+			'type' => 'boolean'
+		];
+
+		$params['graphfields'] = [
+			'default' => false,
+			'message' => 'srf-paramdesc-graph-fields',
+			'manipluatedefault' => false,
+			'type' => 'boolean'
 		];
 
 		return $params;


### PR DESCRIPTION
Handle unusual printout order in 'graph' format, i.e., the one with main column absent or not the first printout.

Per @YOUR1: added 'graphfields' parameter (off by default) that switches non-page properties display to labels within nodes from edges.

Property chains are displayed as edges regardless of the type of the last link.

Unit test for the 'graph' format rewritten and extended.

Bug: #742