### PR TITLE
Remove group from styles resource

### DIFF
--- a/Resources.php
+++ b/Resources.php
@@ -131,8 +131,7 @@ return [
 		'styles'  => [
 			'resources/ext.srf.css',
 		],
-		'position' => 'top',
-		'group' => 'ext.srf'
+		'position' => 'top'
 	],
 
 	// SMW/SRF query/result api module


### PR DESCRIPTION
AFAIK, a group is unnecessary and causes ResourceLoader not to merge the stylesheet with the rest, thus causing an extra web request only to get the CSS for this extension.

This inefficiency is reported by https://www.webpagetest.org as well as https://developers.google.com/speed and NewRelic