### PR TITLE
[datatables] fixes numeric sorting in conjunction with $wgCachePages

### DIFF
--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -80,12 +80,13 @@ class DataTables extends ResultPrinter {
 		$id = $resourceFormatter->session();
 
 		$context = \RequestContext::getMain();
-
-		// $parser = \MediaWiki\MediaWikiServices::getInstance()->getParser();
-		$context->getOutput()->addJsConfigVars( [
-			'wgCategoryCollation' => $GLOBALS['wgCategoryCollation'],
-			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
-		]);
+	
+		// the following unfortunately does not work with $wgCachePages
+		// so we append it in the html elements' attribute below
+		// $context->getOutput()->addJsConfigVars( [
+		// 	'wgCategoryCollation' => $GLOBALS['wgCategoryCollation'],
+		// 	'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
+		// ]);
 
 		// Add options
 		$data['version'] = '0.2.5';
@@ -106,6 +107,7 @@ class DataTables extends ResultPrinter {
 				'class' => 'srf-datatables' . ( $this->params['class'] ? ' ' . $this->params['class'] : '' ),
 				'data-theme' => $this->params['theme'],
 				'data-columnstype' => ( !empty( $this->params['columnstype'] ) ? $this->params['columnstype'] : null ),
+				'data-collation' => !empty( $GLOBALS['smwgEntityCollation'] ) ? $GLOBALS['smwgEntityCollation'] : $GLOBALS['wgCategoryCollation']
 			],
 			Html::element(
 				'div',

--- a/formats/datatables/resources/ext.srf.formats.datatables.js
+++ b/formats/datatables/resources/ext.srf.formats.datatables.js
@@ -270,9 +270,7 @@
 					.map((x) => x.trim())
 					.filter((x) => x !== "");
 
-				var entityCollation =
-					mw.config.get("smwgEntityCollation") ||
-					mw.config.get("mw.config.wgCategoryCollation");
+				var entityCollation = context.data("collation");
 
 				// use the latest set value if one or more column is missing
 				var columnsType = null;


### PR DESCRIPTION
fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/761

the collation isn't added to the output page using `addJsConfigVars` when [$wgCachePages](https://www.mediawiki.org/wiki/Manual:$wgCachePages) is used.

The pull requests adds a workaround in the datatable's php and js files.