### PR TITLE
preferred label and eventcalendar

### DIFF
--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -5,6 +5,7 @@ namespace SRF;
 use Html;
 use SMWOutputs as ResourceManager;
 use SMWQueryResult as QueryResult;
+use SMW\Query\PrintRequest;
 
 /**
  * @since 3.0
@@ -79,7 +80,7 @@ class ResourceFormatter {
 	}
 
 	/**
-	 * @param \SMW\Query\PrintRequest[] $printRequests
+	 * @param PrintRequest[] $printRequests
 	 * @param array $ask
 	 * @return array
 	 */

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -79,7 +79,7 @@ class ResourceFormatter {
 	}
 
 	/**
-	 * @param array $printRequests
+	 * @param PrintRequest[] $printRequests
 	 * @param array $ask
 	 * @return array
 	 */

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -79,7 +79,7 @@ class ResourceFormatter {
 	}
 
 	/**
-	 * @param SMW\Query\PrintRequest[] $printRequests
+	 * @param \SMW\Query\PrintRequest[] $printRequests
 	 * @param array $ask
 	 * @return array
 	 */

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -11,6 +11,7 @@ use SMWQueryResult as QueryResult;
  *
  * @license GPL-2.0-or-later
  * @author mwjames
+ * @reviewer thomas-topway-it
  */
 class ResourceFormatter {
 

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -96,6 +96,9 @@ class ResourceFormatter {
 		// which calls getTypeId in resources/ext.srf.api.results.js
 		// and expects that the printrequest label and printouts custom label
 		// retrieved from the below, match
+		// 
+		// @TODO all this method can be removed as long as the issue
+		// can be fixed at SMW level: PrintRequest's Serializer -> doSerializeProp
 
 		// map canonical labels to labels
 		$mapLabels = [];
@@ -105,11 +108,14 @@ class ResourceFormatter {
 
 		// @see resources/ext.srf.api.query.js
 		foreach ( $ask['printouts'] as $key => $value ) {
+			// *** the regex reflects a similar regex in the method
+			// ext.srf.api.query.js -> toList, so in this sense it
+			// is consistent
 			preg_match( '/^\s*[?&]\s*(.*?)\s*(#.+)?\s*(=.+)?\s*$/', $value, $match );
 
 			// add custom label if added through Preferred property label
 			// rather than in the ask query itself
-			if ( empty( $match[3] ) && $mapLabels[$match[1]] !== array_search($mapLabels[$match[1]], $mapLabels ) ) {
+			if ( empty( $match[3] ) && $mapLabels[$match[1]] !== array_search( $mapLabels[$match[1]], $mapLabels ) ) {
 				$ask['printouts'][$key] .= '=' . $mapLabels[$match[1]];
 			}
 		}
@@ -133,7 +139,7 @@ class ResourceFormatter {
 			}
 		}
 
-		$ask = self::appendPreferredPropertyLabel($queryResult->getPrintRequests(), $ask );
+		$ask = self::appendPreferredPropertyLabel( $queryResult->getPrintRequests(), $ask );
 
 		// Combine all data into one object
 		$data = [
@@ -147,3 +153,4 @@ class ResourceFormatter {
 	}
 
 }
+

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -109,8 +109,7 @@ class ResourceFormatter {
 		// @see resources/ext.srf.api.query.js
 		foreach ( $ask['printouts'] as $key => $value ) {
 			// *** the regex reflects a similar regex in the method
-			// ext.srf.api.query.js -> toList, so in this sense it
-			// is consistent
+			// ext.srf.api.query.js -> toList
 			preg_match( '/^\s*[?&]\s*(.*?)\s*(#.+)?\s*(=.+)?\s*$/', $value, $match );
 
 			// add custom label if added through Preferred property label

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -11,7 +11,7 @@ use SMWQueryResult as QueryResult;
  *
  * @license GPL-2.0-or-later
  * @author mwjames
- * @reviewer thomas-topway-it
+ * @contributor thomas-topway-it
  */
 class ResourceFormatter {
 

--- a/src/ResourceFormatter.php
+++ b/src/ResourceFormatter.php
@@ -79,7 +79,7 @@ class ResourceFormatter {
 	}
 
 	/**
-	 * @param PrintRequest[] $printRequests
+	 * @param SMW\Query\PrintRequest[] $printRequests
 	 * @param array $ask
 	 * @return array
 	 */


### PR DESCRIPTION
fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/764

***attention! the proposed solution is a workaround for the use with SRF's `ext.srf.api.query.js -> toList` (a regex to match the printout label and custom label), however a preferred solution would be at SMW level trying to fix PrintRequest's `Serializer -> doSerializeProp`