### PR TITLE
fixes issue 782 jqplotchart label error with DistributionResults and link != none

### DIFF
--- a/formats/jqplot/SRF_jqPlot.php
+++ b/formats/jqplot/SRF_jqPlot.php
@@ -13,6 +13,14 @@
  */
 abstract class SRFjqPlot extends SMWAggregatablePrinter {
 
+	/**
+	 * @inheritDoc
+	 */
+	protected function getLinker( $firstcol = false ) {
+		// *** force null since labels are never clickable
+                return null;
+        }
+
 	public static function getCommonParams() {
 		$params = [];
 


### PR DESCRIPTION
forces $linker to null

fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/782