### PR TITLE
Replace deprecated $wgHooks

### DIFF
--- a/SemanticResultFormats.php
+++ b/SemanticResultFormats.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticResultFormats/
  *
@@ -51,31 +53,28 @@ class SemanticResultFormats {
 	 * @since 2.5
 	 */
 	public static function registerHooks() {
-		$formatDir = __DIR__ . '/formats/';
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 
+		$hookContainer->register( 'ParserFirstCallInit', 'SRFParserFunctions::registerFunctions' );
+		$hookContainer->register( 'UnitTestsList', 'SRFHooks::registerUnitTests' );
 
-		unset( $formatDir );
-
-		$GLOBALS['wgHooks']['ParserFirstCallInit'][] = 'SRFParserFunctions::registerFunctions';
-		$GLOBALS['wgHooks']['UnitTestsList'][] = 'SRFHooks::registerUnitTests';
-
-		$GLOBALS['wgHooks']['ResourceLoaderGetConfigVars'][] = 'SRFHooks::onResourceLoaderGetConfigVars';
+		$hookContainer->register( 'ResourceLoaderGetConfigVars', 'SRFHooks::onResourceLoaderGetConfigVars' );
 
 		// Format hooks
-		$GLOBALS['wgHooks']['OutputPageParserOutput'][] = 'SRF\Filtered\Hooks::onOutputPageParserOutput';
-		$GLOBALS['wgHooks']['MakeGlobalVariablesScript'][] = 'SRF\Filtered\Hooks::onMakeGlobalVariablesScript';
+		$hookContainer->register( 'OutputPageParserOutput', 'SRF\Filtered\Hooks::onOutputPageParserOutput' );
+		$hookContainer->register( 'MakeGlobalVariablesScript', 'SRF\Filtered\Hooks::onMakeGlobalVariablesScript' );
 
-		$GLOBALS['wgHooks']['SMW::Store::BeforeQueryResultLookupComplete'][] = 'SRF\DataTables\Hooks::onSMWStoreBeforeQueryResultLookupComplete';
+		$hookContainer->register( 'SMW::Store::BeforeQueryResultLookupComplete', 'SRF\DataTables\Hooks::onSMWStoreBeforeQueryResultLookupComplete' );
 
 		// register API modules
 		$GLOBALS['wgAPIModules']['ext.srf.slideshow.show'] = 'SRFSlideShowApi';
 		$GLOBALS['wgAPIModules']['ext.srf.datatables.api'] = 'SRF\DataTables\Api';
 
 		// User preference
-		$GLOBALS['wgHooks']['SMW::GetPreferences'][] = 'SRFHooks::onGetPreferences';
+		$hookContainer->register( 'SMW::GetPreferences', 'SRFHooks::onGetPreferences' );
 
 		// Allows last minute changes to the output page, e.g. adding of CSS or JavaScript by extensions
-		$GLOBALS['wgHooks']['BeforePageDisplay'][] = 'SRFHooks::onBeforePageDisplay';
+		$hookContainer->register( 'BeforePageDisplay', 'SRFHooks::onBeforePageDisplay' );
 	}
 
 	/**
@@ -94,11 +93,12 @@ class SemanticResultFormats {
 				);
 			}
 		}
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 
 		// Admin Links hook needs to be called in a delayed way so that it
 		// will always be called after SMW's Admin Links addition; as of
 		// SMW 1.9, SMW delays calling all its hook functions.
-		$GLOBALS['wgHooks']['AdminLinks'][] = 'SRFHooks::addToAdminLinks';
+		$hookContainer->register( 'AdminLinks', 'SRFHooks::addToAdminLinks' );
 
 		$GLOBALS['srfgScriptPath'] = ( $GLOBALS['wgExtensionAssetsPath'] === false ? $GLOBALS['wgScriptPath'] . '/extensions' : $GLOBALS['wgExtensionAssetsPath'] ) . '/SemanticResultFormats';
 


### PR DESCRIPTION
HookContainer service is available since 1.35, just like extension.json compatibility statement, so no need of a compatibility layer.

This change is similar to [this one in CentralAuth](https://gerrit.wikimedia.org/r/c/904453).

Issue: #781