### PR TITLE
Fix issue 784 slidesToShow

### DIFF
--- a/formats/carousel/Carousel.php
+++ b/formats/carousel/Carousel.php
@@ -4,7 +4,7 @@
  *
  * @license GPL-2.0-or-later
  *
- * @author thomas-topway-it <thomas.topway.it@mail.com>
+ * @author thomas-topway-it for KM-A
  */
 namespace SRF;
 
@@ -261,10 +261,12 @@ class Carousel extends ResultPrinter {
 			'default' => "window",
 		];
 
-		$params['slick-responsive'] = [
-		 	'message' => 'srf-paramdesc-carousel-slick-option',
-		 	'default' => null,
-		];
+		// @see https://github.com/kenwheeler/slick/#responsive-option-example
+		// $params['slick-responsive'] = [
+		// 	'type' => 'string',
+		//  	'message' => 'srf-paramdesc-carousel-slick-option',
+		//  	'default' => null,
+		// ];
 
 		$params['slick-rows'] = [
 			'type' => 'integer',
@@ -406,8 +408,6 @@ class Carousel extends ResultPrinter {
 		// or ...
 		// SMWOutputs::requireResource( 'ext.srf.carousel' );
 
-		// print_r($data);
-
 		/*
 		 * first retrieve explicitly set properties:
 		 * titleproperty, captionproperty, imageproperty, linkproperty
@@ -422,6 +422,28 @@ class Carousel extends ResultPrinter {
 			$printReqLabels[ $value['label'] ] = $value['typeid'];
 		}
 
+		$slidestoshow = $this->params['slick-slidestoshow'];
+
+		if ( empty( $this->params['width'] ) ) {
+			$this->params['width'] = '100%';
+		}
+
+		preg_match( '/^(\d+)(.+)?$/', $this->params['width'], $match );
+		
+		$styleImg = [ 'object-fit: cover' ];
+		
+		$absoluteUnits = [ 'cm', 'mm', 'in', 'px', 'pt', 'pc' ];
+		
+		// @see https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/784
+		if ( !empty( $slidestoshow ) && is_int( $slidestoshow ) && !empty( $match[1] ) ) {
+			if ( empty( $match[2] ) ) {
+				$match[2] = 'px';
+			}
+			$styleImg[] = 'max-width:' . ( in_array( $match[2], $absoluteUnits ) ?
+				( $match[1] / $slidestoshow ) . $match[2]
+				: '100%' );
+		}
+		
 		$styleAttr = [ 'width', 'height' ];
 		$style = [];
 		foreach( $styleAttr as $attr ) {
@@ -429,18 +451,6 @@ class Carousel extends ResultPrinter {
 				$style[ $attr ] = "$attr: " . $this->params[$attr];
 			}
 		}
-
-		if ( !array_key_exists( 'width', $style ) ) {
-			$style[ 'width' ] = 'width: 100%';
-		}
-
-		$styleImg = array_map( static function ( $value ) {
-			// return 'max-' . $value;
-			return $value;
-		}, $style );
-
-		$styleImg[] = 'object-fit: cover';
-		$styleImg = implode( '; ', $styleImg );
 
 		$parser = MediaWikiServices::getInstance()->getParser();
 		$items = [];
@@ -529,7 +539,7 @@ class Carousel extends ResultPrinter {
 			$innerContent = Html::rawElement( 'img', [
 					'src' => $imageValue,
 					'alt' => ( $titleValue ?? $captionValue ? strip_tags( $captionValue ) : $title_->getText() ),
-					'style' => $styleImg,
+					'style' => implode( '; ',  $styleImg ),
 					'class' => "slick-slide-content img"
 				] );
 
@@ -601,4 +611,3 @@ class Carousel extends ResultPrinter {
 	}
 
 }
-

--- a/formats/carousel/resources/ext.srf.formats.carousel.css
+++ b/formats/carousel/resources/ext.srf.formats.carousel.css
@@ -1,7 +1,7 @@
 
 .slick-prev:before, 
 .slick-next:before {
-	color: white;
+	color: #3498db;
 	font-size: 30px;
 }
 

--- a/formats/carousel/resources/ext.srf.formats.carousel.css
+++ b/formats/carousel/resources/ext.srf.formats.carousel.css
@@ -26,6 +26,7 @@
     background: rgba(0,0,0,.65);
     color: white;
     font-size: smaller;
+    width: 100%;
 }
 
 .slick-slide .slick-slide-content.caption-title {

--- a/tests/phpunit/Integration/JSONScript/TestCases/carousel-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/carousel-01.json
@@ -52,7 +52,7 @@
 			"subject": "Test/Carousel/T.1",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"slick-slide\" data-url=\".*/index.php/File:Gallery01.png\"><img src=\".*/images/7/7f/Gallery01.png\" alt=\"caption a\" style=\"height: 400px; width: 100%; object-fit: cover\" class=\"slick-slide-content img\" /><div class=\"slick-slide-content caption\"><div class=\"slick-slide-content caption-title\">title a</div><div class=\"slick-slide-content caption-text\">caption a</div></div></div></div>"
+					"<div class=\"slick-slide\" data-url=\".*/index.php/File:Gallery01.png\"><img src=\".*/images/7/7f/Gallery01.png\" alt=\"caption a\".* class=\"slick-slide-content img\".*/><div class=\"slick-slide-content caption\"><div class=\"slick-slide-content caption-title\">title a</div><div class=\"slick-slide-content caption-text\">caption a</div></div></div></div>"
 				]
 			}
 
@@ -63,7 +63,7 @@
 			"subject": "Test/Carousel/T.2",
 			"assert-output": {
 				"to-contain": [
-					"<div class=\"slick-slide\" data-url=\".*/index.php/Test/Carousel_test\"><img src=\".*/images/7/7f/Gallery01.png\" alt=\"abc\" style=\"height: 400px; width: 100%; object-fit: cover\" class=\"slick-slide-content img\" /><div class=\"slick-slide-content caption\"><div class=\"slick-slide-content caption-title\">Carousel test</div><div class=\"slick-slide-content caption-text\">abc</div></div></div></div>"
+					"<div class=\"slick-slide\" data-url=\".*/index.php/Test/Carousel_test\"><img src=\".*/images/7/7f/Gallery01.png\" alt=\"abc\".* class=\"slick-slide-content img\".*/><div class=\"slick-slide-content caption\"><div class=\"slick-slide-content caption-title\">Carousel test</div><div class=\"slick-slide-content caption-text\">abc</div></div></div></div>"
 				]
 			}
 		}


### PR DESCRIPTION
 - fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/784
- fixes default arrow color

the issue was caused by 2 concurrent problems, the parameter `slick-responsive` with wrong default value prevented all subsequent parameters to work, including `slick-slidesToShow`, now all the parameters listed here https://www.semantic-mediawiki.org/wiki/Help:Carousel_format should work correctly.
It has also been implemented the suggestion of @michaelfreiberg mentioned in the same issue

