### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,6 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
-            smw_version: dev-master
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:latest"
-            coverage: false
-            experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}


### PR DESCRIPTION
Removed MediaWiki 1.40 because of:

1. I don't remember that something related to Semantic MediaWiki has ever officially supported a non-LTS version of MediaWiki
2. Tests are failing for MediaWiki 1.40, it's not worth fixing it as MediaWiki 1.40 is non-LTS, because of previous reasons.