### PR TITLE
Allow for NONCEs on inline scripts

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -77,6 +77,9 @@ final class SRFUtils {
 	 */
 	public static function makeVariablesScript( $data, $nonce = null ) {
 		$script = ResourceLoader::makeConfigSetScript( $data );
+		if ( $nonce === null ) {
+			$nonce = RequestContext::getMain()->getOutput()->getCSP()->getNonce();
+		}
 
 		return ResourceLoader::makeInlineScript( $script, $nonce );
 	}


### PR DESCRIPTION
In order to support CSP-Header.

See also
* https://github.com/SemanticMediaWiki/SemanticResultFormats/commit/6e62a0036e1b0a2c265aafa6970b3611752bf64e
* https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/785