### PR TITLE
Restore datatable filter responsive handling

### DIFF
--- a/formats/datatables/resources/ext.srf.formats.datatables.css
+++ b/formats/datatables/resources/ext.srf.formats.datatables.css
@@ -35,4 +35,15 @@
 	right: 8px;
 }
 
+/* Restore responsiveness from datatables that is overriden by SRF above */
+@media screen and ( max-width: 640px ) {
+	.srf-datatable .dataTables_filter,
+	.srf-datatable .dataTables_length {
+		float: none;
+	}
 
+	.srf-datatable .dt-buttons,
+	.srf-datatable .dataTables_filter{
+		margin-right: 0;
+	}
+}


### PR DESCRIPTION
The styles added by SRF was overriding the responsive media query rules set by datatables. This should restore the behavior.