### PR TITLE
Add CHAIN field support in datatables ajax API

### DIFF
--- a/formats/datatables/Api.php
+++ b/formats/datatables/Api.php
@@ -107,11 +107,11 @@ class Api extends ApiBase {
 			// create property from property key
 			if ( $printoutData[0] === SMWPrintRequest::PRINT_PROP ) {
 				$data_ = $dataValueFactory->newPropertyValueByLabel( $printoutData[1] );
-			} elseif ($printoutData[0] === SMWPrintRequest::PRINT_CHAIN){
+			} elseif ( $printoutData[0] === SMWPrintRequest::PRINT_CHAIN ) {
 				$data_ = $dataValueFactory->newDataValueByType(
 					PropertyChainValue::TYPE_ID
 				);
-				$data_->setUserValue($printoutData[1]);
+				$data_->setUserValue( $printoutData[1] );
 			} else {
 				$data_ = null;
 				if ( $hasMainlabel && trim( $parameters['mainlabel'] ) === '-' ) {

--- a/formats/datatables/Api.php
+++ b/formats/datatables/Api.php
@@ -14,6 +14,7 @@ namespace SRF\DataTables;
 use ApiBase;
 use ParamProcessor\ParamDefinition;
 use SMW\DataValueFactory;
+use SMW\DataValues\PropertyChainValue;
 use SMW\Services\ServicesFactory;
 use SMWPrintRequest;
 use SMWQueryProcessor;
@@ -106,6 +107,11 @@ class Api extends ApiBase {
 			// create property from property key
 			if ( $printoutData[0] === SMWPrintRequest::PRINT_PROP ) {
 				$data_ = $dataValueFactory->newPropertyValueByLabel( $printoutData[1] );
+			} elseif ($printoutData[0] === SMWPrintRequest::PRINT_CHAIN){
+				$data_ = $dataValueFactory->newDataValueByType(
+					PropertyChainValue::TYPE_ID
+				);
+				$data_->setUserValue($printoutData[1]);
 			} else {
 				$data_ = null;
 				if ( $hasMainlabel && trim( $parameters['mainlabel'] ) === '-' ) {


### PR DESCRIPTION
## How to reproduce
Create a page with following content
```
{{#subobject: A |Text=A }}
{{#subobject: B |Text=B }}
{{#subobject: C |Text=C }}
{{#ask:
[[-Has subobject::{{FULLPAGENAME}}]]
|?Has subobject.Text
|format=datatables
|datatables-pageLength=2
|limit=1
}}
```

When SMW renders the page, `Processing...` and `Loading...` stays displayed.

![image](https://github.com/SemanticMediaWiki/SemanticResultFormats/assets/1468181/d1947919-abbf-445a-acd0-708163084215)

Following is the response from api action=`ext.srf.datatables.api`, in browser devtool.

```json
{
    "error": {
        "code": "internal_api_error_InvalidArgumentException",
        "info": "[3f28f227f0de38a93bb53121] Exception caught: Data provided for print request does not fit the type of printout.",
        "errorclass": "InvalidArgumentException",
        "*": "InvalidArgumentException at /var/www/html/extensions/SemanticMediaWiki/src/Query/PrintRequest.php(98)\nfrom /var/www/html/extensions/SemanticMediaWiki/src/Query/PrintRequest.php(98)\n#0 /var/www/html/extensions/SemanticResultFormats/formats/datatables/Api.php(124): SMW\\Query\\PrintRequest->__construct(integer, string, NULL, string, array)\n#1 /var/www/html/includes/api/ApiMain.php(1907): SRF\\DataTables\\Api->execute()\n#2 /var/www/html/includes/api/ApiMain.php(884): ApiMain->executeAction()\n#3 /var/www/html/includes/api/ApiMain.php(855): ApiMain->executeActionWithErrorHandling()\n#4 /var/www/html/api.php(91): ApiMain->execute()\n#5 /var/www/html/api.php(46): wfApiMain()\n#6 {main}"
    }
}
```