### PR TITLE
add more specific term for CSS classes 'enabled' and 'disabled'

### DIFF
--- a/formats/filtered/resources/js/ext.srf.filtered.js
+++ b/formats/filtered/resources/js/ext.srf.filtered.js
@@ -306,8 +306,8 @@ var Filter = /** @class */ (function () {
         var _this = this;
         this.disabled = true;
         this.outerTarget
-            .removeClass('enabled')
-            .addClass('disabled');
+            .removeClass('filtered-filter-enabled')
+            .addClass('filtered-filter-disabled');
         this.collapse();
         this.target.promise().then(function () { return _this.controller.onFilterUpdated(_this.filterId); });
     };
@@ -315,8 +315,8 @@ var Filter = /** @class */ (function () {
         var _this = this;
         this.disabled = false;
         this.outerTarget
-            .removeClass('disabled')
-            .addClass('enabled');
+            .removeClass('filtered-filter-disabled')
+            .addClass('filtered-filter-enabled');
         if (!this.collapsed) {
             this.uncollapse();
         }
@@ -359,7 +359,7 @@ var Filter = /** @class */ (function () {
         this.target = $('<div class="filtered-filter-container">');
         this.outerTarget
             .append(this.target)
-            .addClass('enabled');
+            .addClass('filtered-filter-enabled');
         this.addOnOffSwitch();
         this.addLabel();
         this.addControlForCollapsing();
@@ -377,7 +377,7 @@ var Filter = /** @class */ (function () {
                 var onOffControl = $("<div class=\"filtered-filter-onoff on\"></div>");
                 this.target.before(onOffControl);
                 onOffControl.click(function () {
-                    if (_this.outerTarget.hasClass('enabled')) {
+                    if (_this.outerTarget.hasClass('filtered-filter-enabled')) {
                         _this.disable();
                     }
                     else {

--- a/formats/filtered/resources/ts/Filtered/Filter/Filter.ts
+++ b/formats/filtered/resources/ts/Filtered/Filter/Filter.ts
@@ -31,8 +31,8 @@ export abstract class Filter{
 		this.disabled = true;
 
 		this.outerTarget
-		.removeClass( 'enabled' )
-		.addClass( 'disabled' );
+		.removeClass( 'filtered-filter-enabled' )
+		.addClass( 'filtered-filter-disabled' );
 
 		this.collapse();
 
@@ -43,8 +43,8 @@ export abstract class Filter{
 		this.disabled = false;
 
 		this.outerTarget
-		.removeClass( 'disabled' )
-		.addClass( 'enabled' );
+		.removeClass( 'filtered-filter-disabled' )
+		.addClass( 'filtered-filter-enabled' );
 
 		if ( ! this.collapsed ) {
 			this.uncollapse();
@@ -99,7 +99,7 @@ export abstract class Filter{
 
 		this.outerTarget
 		.append( this.target )
-		.addClass( 'enabled' );
+		.addClass( 'filtered-filter-enabled' );
 
 		this.addOnOffSwitch();
 		this.addLabel();
@@ -127,7 +127,7 @@ export abstract class Filter{
 
 				onOffControl.click( () => {
 
-					if ( this.outerTarget.hasClass('enabled' ) ) {
+					if ( this.outerTarget.hasClass('filtered-filter-enabled' ) ) {
 						this.disable();
 					} else {
 						this.enable();

--- a/tests/qunit/formats/ext.srf.formats.filtered.test.js
+++ b/tests/qunit/formats/ext.srf.formats.filtered.test.js
@@ -308,8 +308,8 @@ var Filter = /** @class */ (function () {
         var _this = this;
         this.disabled = true;
         this.outerTarget
-            .removeClass('enabled')
-            .addClass('disabled');
+            .removeClass('filtered-filter-enabled')
+            .addClass('filtered-filter-disabled');
         this.collapse();
         this.target.promise().then(function () { return _this.controller.onFilterUpdated(_this.filterId); });
     };
@@ -317,8 +317,8 @@ var Filter = /** @class */ (function () {
         var _this = this;
         this.disabled = false;
         this.outerTarget
-            .removeClass('disabled')
-            .addClass('enabled');
+            .removeClass('filtered-filter-disabled')
+            .addClass('filtered-filter-enabled');
         if (!this.collapsed) {
             this.uncollapse();
         }
@@ -361,7 +361,7 @@ var Filter = /** @class */ (function () {
         this.target = $('<div class="filtered-filter-container">');
         this.outerTarget
             .append(this.target)
-            .addClass('enabled');
+            .addClass('filtered-filter-enabled');
         this.addOnOffSwitch();
         this.addLabel();
         this.addControlForCollapsing();
@@ -379,7 +379,7 @@ var Filter = /** @class */ (function () {
                 var onOffControl = $("<div class=\"filtered-filter-onoff on\"></div>");
                 this.target.before(onOffControl);
                 onOffControl.click(function () {
-                    if (_this.outerTarget.hasClass('enabled')) {
+                    if (_this.outerTarget.hasClass('filtered-filter-enabled')) {
                         _this.disable();
                     }
                     else {


### PR DESCRIPTION
Terms for CSS classes '**enabled**' and '**disabled**' has been updated and changed to more specific terms. 

- 'enabled'  => 'filtered-filter-enabled';
- 'disable' => 'filtered-filter-disable' 

