### PR TITLE
Updates to wfFindFile again

### DIFF
--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -109,7 +109,7 @@ class SRFDygraphs extends SMWResultPrinter {
 						$aggregatedValues['subject'] = $this->makePageFromTitle(
 							$title
 						)->getLongHTMLText( $this->getLinker( $field->getResultSubject() ) );
-						$aggregatedValues['url'] = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title )->getUrl();						
+						$aggregatedValues['url'] = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title )->getUrl();
 						$dataSource = true;
 						continue;
 					} elseif ( $dataItem->getDIType() == SMWDataItem::TYPE_URI && $this->params['datasource'] === 'url' && !$dataSource ) {

--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -75,13 +75,7 @@ class SRFDygraphs extends SMWResultPrinter {
 					$aggregatedValues['subject'] = $this->makePageFromTitle( $subject->getTitle() )->getLongHTMLText(
 						$this->getLinker( $field->getResultSubject() )
 					);
-					if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
-						$aggregatedValues['url'] = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $subject->getTitle() )->getUrl();
-					} else {
-						// Before  MW 1.34
-						$aggregatedValues['url'] = wfFindFile( $subject->getTitle() )->getUrl();
-					}
-
+					$aggregatedValues['url'] = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $subject->getTitle() )->getUrl();
 					$dataSource = true;
 				}
 
@@ -115,7 +109,7 @@ class SRFDygraphs extends SMWResultPrinter {
 						$aggregatedValues['subject'] = $this->makePageFromTitle(
 							$title
 						)->getLongHTMLText( $this->getLinker( $field->getResultSubject() ) );
-						$aggregatedValues['url'] = wfFindFile( $title )->getUrl();
+						$aggregatedValues['url'] = MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title )->getUrl();						
 						$dataSource = true;
 						continue;
 					} elseif ( $dataItem->getDIType() == SMWDataItem::TYPE_URI && $this->params['datasource'] === 'url' && !$dataSource ) {

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -364,10 +364,6 @@ class MediaPlayer extends ResultPrinter {
 	 * @return bool|File
 	 */
 	private function findFile( Title $title ) {
-		if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
-			return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
-		}
-		// TODO: Remove when min MW version is 1.34
-		return wfFindFile( $title );
+		return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $title );
 	}
 }


### PR DESCRIPTION
No need to support the older method wfFindFile (pre-MW 1.34). Since SRF 4.0.x, the minimum version is MW 1.35. Also corrected an earlier oversight.
#778