### PR TITLE
Update ext.smw.style to ext.smw.styles

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -19,7 +19,7 @@ final class SRFUtils {
 	 * @since 1.8
 	 */
 	public static function htmlProcessingElement( $isHtml = true ) {
-		SMWOutputs::requireResource( 'ext.smw.style' );
+		SMWOutputs::requireResource( 'ext.smw.styles' );
 
 		return Html::rawElement(
 			'div',


### PR DESCRIPTION
> ⚠️ This is a breaking change from SMW 5.0.0

The module is renamed into ext.smw.styles in SMW 5.0.0
https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/c239553c7ad5c39cb05ebf3b9661f64e728c0e2b
