### PR TITLE
Support showing all rows as a length option in DataTables

### DIFF
--- a/Resources.php
+++ b/Resources.php
@@ -967,6 +967,7 @@ return [
 			'ext.srf.widgets'
 		],
 		'messages' => [
+			'allmessages-filter-all',
 			'srf-ui-datatables-label-conditions',
 			'srf-ui-datatables-label-parameters',
 			'srf-ui-datatables-label-filters',

--- a/formats/datatables/resources/ext.srf.formats.datatables.js
+++ b/formats/datatables/resources/ext.srf.formats.datatables.js
@@ -558,6 +558,14 @@
 				});
 			}
 
+			// Replace -1 in lengthMenu with 'all' label
+			var showAll = options.lengthMenu.indexOf( -1 );
+			if ( showAll !== -1 ) {
+				var labels = options.lengthMenu.slice();
+				labels[showAll] = mw.msg( 'allmessages-filter-all' ); // stealing MW core messages :D
+				options.lengthMenu = [ options.lengthMenu, labels ];
+			}
+
 			var query = data.query.ask;
 			var printouts = table.data("printouts");
 			var queryString = query.conditions;


### PR DESCRIPTION
By adding `-1` to `datatables-lengthMenu`, all rows can be shown.

![image](https://github.com/user-attachments/assets/7034f56a-dc59-4ca6-9e46-4b635575d060)
