### PR TITLE
Fix for #614

### DIFF
--- a/formats/incoming/SRF_Incoming.php
+++ b/formats/incoming/SRF_Incoming.php
@@ -141,19 +141,24 @@ class SRFIncoming extends ResultPrinter {
 			$result = implode( $this->params['sep'], array_keys( $data ) );
 		}
 
-		// Beautify class selector
-		$class = $this->params['template'] ? 'srf-incoming ' . str_replace(
+		if ( $this->params['template'] ) {
+			// Beautify class selector		
+			$class = 'srf-incoming ' . str_replace(
 				" ",
 				"-",
 				$this->params['template']
-			) : 'srf-incoming';
+			);
 
-		// Output
-		return Html::rawElement(
-			'div',
-			[ 'class' => $class ],
-			$result
-		);
+			// Output
+			return Html::rawElement(
+				'div',
+				[ 'class' => $class ],
+				$result
+			);
+		} else {
+			// Output without template
+			return $result;
+		}
 	}
 
 	/**

--- a/formats/incoming/SRF_Incoming.php
+++ b/formats/incoming/SRF_Incoming.php
@@ -142,7 +142,7 @@ class SRFIncoming extends ResultPrinter {
 		}
 
 		if ( $this->params['template'] ) {
-			// Beautify class selector		
+			// Beautify class selector
 			$class = 'srf-incoming ' . str_replace(
 				" ",
 				"-",


### PR DESCRIPTION
Fix for #614. When no template is used, removes the html (a div element with the 'srf-incoming' class) from the result so that it allows for further reuse.