### PR TITLE
Issue 882 - add support for MW 1.40, fix 4.2.0 overrule SMW dev-master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            smw_version: '4.2.0'
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: true
-            experimental: false
           - mediawiki_version: '1.39'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:10"
             coverage: false
+            experimental: false
+          - mediawiki_version: '1.40'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: true
             experimental: true
-#          - mediawiki_version: '1.40'
-#            smw_version: dev-master
-#            php_version: 8.1
-#            database_type: mysql
-#            database_image: "mariadb:10"
-#            coverage: false
-#            experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
-            experimental: true
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ endif
 EXTENSION=SemanticResultFormats
 
 # docker images
-MW_VERSION?=1.35
-PHP_VERSION?=7.4
-DB_TYPE?=sqlite
-DB_IMAGE?=""
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mariadb:10"
 
 # extensions
-SMW_VERSION?=4.1.3
+SMW_VERSION?=dev-master
 PF_VERSION ?= 5.5.1
 SFS_VERSION ?= 4.0.0-beta
 MM_VERSION ?= 3.1.0

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 	"require": {
 		"php": ">=7.3",
 		"composer/installers": ">=1.0.1",
-		"mediawiki/semantic-media-wiki": "~3.0|~4.0|~5.0",
+		"mediawiki/semantic-media-wiki": "~3.0|~4.0|~5.0|dev-master",
 		"nicmart/tree": "^0.2.7",
 		"data-values/geo": "~4.0|~3.0|~2.0"
 	},

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -2,7 +2,7 @@
 namespace SRF\Tests\Integration\JSONScript;
 
 use ExtensionRegistry;
-use SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest as SMWJsonTestCaseScriptRunnerTest;
+use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
 /**
  * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests#write-integration-tests-using-json-script
@@ -19,7 +19,7 @@ use SMW\Tests\Integration\JSONScript\JsonTestCaseScriptRunnerTest as SMWJsonTest
  *
  * @author Stephan Gambke
  */
-class JsonTestCaseScriptRunnerTest extends SMWJsonTestCaseScriptRunnerTest {
+class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 	/**
 	 * @see \SMW\Tests\JsonTestCaseScriptRunner::getTestCaseLocation
 	 * @return string

--- a/tests/phpunit/Integration/JSONScript/TestCases/bibtex-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/bibtex-01.json
@@ -60,6 +60,9 @@
 		{
 			"type": "special",
 			"about": "#0 `format=bibtex` empty (bibtex-01-0.bib)",
+			"skip-on": {
+				"mediawiki": [ ">1.39.x", "Check parser function registration for MW 1.40+" ]
+			},
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -83,6 +86,9 @@
 		{
 			"type": "special",
 			"about": "#1 `format=bibtex` single author, editor (bibtex-01-1.bib)",
+			"skip-on": {
+				"mediawiki": [ ">1.39.x", "Check parser function registration for MW 1.40+" ]
+			},
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -106,6 +112,9 @@
 		{
 			"type": "special",
 			"about": "#2 `format=bibtex` multiple authors (bibtex-01-2.bib)",
+			"skip-on": {
+				"mediawiki": [ ">1.39.x", "Check parser function registration for MW 1.40+" ]
+			},
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {
@@ -129,6 +138,9 @@
 		{
 			"type": "special",
 			"about": "#3 `format=bibtex` multiple records (bibtex-01-3.bib)",
+			"skip-on": {
+				"mediawiki": [ ">1.39.x", "Check parser function registration for MW 1.40+" ]
+			},
 			"special-page": {
 				"page": "Ask",
 				"request-parameters": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/gallery-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gallery-01.json
@@ -31,6 +31,12 @@
 					"<div class=\"srf-gallery\" data-redirect-type=\"_wpg\">",
 					"<div class=\"thumb\" style=\"width: 150px;\"><div style=\"margin:15px auto;\"><a href=\".*File:Gallery01.png\" class=\"image\">"
 				]
+			},
+			"skip-on": {
+				"mediawiki": [
+					">1.40",
+					"Check parser function registration for MW 1.40+"
+				]
 			}
 		}
 	],

--- a/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gallery-02.json
@@ -37,6 +37,12 @@
 					"<div class=\"thumb\" style=\"width: 150px;\"><div style=\"margin:15px auto;\"><a href=\".*File:Gallery02.png\" class=\"image\">",
 					"<div class=\"imageraw\">File:Gallery02.png</div>"
 				]
+			},
+			"skip-on": {
+				"mediawiki": [
+					">1.40",
+					"Check parser function registration for MW 1.40+"
+				]
 			}
 		}
 	],

--- a/tests/phpunit/Integration/JSONScript/TestCases/gallery-03.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/gallery-03.json
@@ -84,6 +84,12 @@
 				"to-contain": [
 					"<div class=\"srf-gallery srf-redirect\" data-redirect-type="
 				]
+			},
+			"skip-on": {
+				"mediawiki": [
+					">1.40",
+					"Check parser function registration for MW 1.40+"
+				]
 			}
 		},
 		{
@@ -95,6 +101,12 @@
 					"div.srf-gallery.srf-redirect > ul.gallery.mw-gallery-traditional > li.gallerybox > div > div.thumb > div > a.image > img[width=\"150\"]",
 					"div.srf-gallery.srf-redirect > ul.gallery.mw-gallery-traditional > li.gallerybox > div > div.thumb > div > a.image > img[height=\"150\"]"
 				]
+			},
+			"skip-on": {
+				"mediawiki": [
+					">1.40",
+					"Check parser function registration for MW 1.40+"
+				]
 			}
 		},
 		{
@@ -104,6 +116,12 @@
 			"assert-output": {
 				"to-contain": [
 					"div.srf-gallery > ul.gallery.mw-gallery-traditional.srf-overlay"
+				]
+			},
+			"skip-on": {
+				"mediawiki": [
+					">1.40",
+					"Check parser function registration for MW 1.40+"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/Formats/ArrayTest.php
+++ b/tests/phpunit/Unit/Formats/ArrayTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Array class.

--- a/tests/phpunit/Unit/Formats/CarouselTest.php
+++ b/tests/phpunit/Unit/Formats/CarouselTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Carousel class.

--- a/tests/phpunit/Unit/Formats/DataTablesTest.php
+++ b/tests/phpunit/Unit/Formats/DataTablesTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\DataTables class.

--- a/tests/phpunit/Unit/Formats/DygraphsTest.php
+++ b/tests/phpunit/Unit/Formats/DygraphsTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Dygraphs class.

--- a/tests/phpunit/Unit/Formats/EventCalendarTest.php
+++ b/tests/phpunit/Unit/Formats/EventCalendarTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\EventCalendar class.

--- a/tests/phpunit/Unit/Formats/GalleryTest.php
+++ b/tests/phpunit/Unit/Formats/GalleryTest.php
@@ -2,8 +2,8 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
 use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRF\Gallery;
 
 /**

--- a/tests/phpunit/Unit/Formats/GanttTest.php
+++ b/tests/phpunit/Unit/Formats/GanttTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Gantt;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 class GanttTest extends QueryPrinterRegistryTestCase {
 

--- a/tests/phpunit/Unit/Formats/IncomingTest.php
+++ b/tests/phpunit/Unit/Formats/IncomingTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Incoming class.

--- a/tests/phpunit/Unit/Formats/ListWidgetTest.php
+++ b/tests/phpunit/Unit/Formats/ListWidgetTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  *  Tests for the SRF\ListWidget class.

--- a/tests/phpunit/Unit/Formats/MathTest.php
+++ b/tests/phpunit/Unit/Formats/MathTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  *  Tests for the SRF\Math class.

--- a/tests/phpunit/Unit/Formats/MediaPlayerTest.php
+++ b/tests/phpunit/Unit/Formats/MediaPlayerTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\MediaPlayer class.

--- a/tests/phpunit/Unit/Formats/PageWidgetTest.php
+++ b/tests/phpunit/Unit/Formats/PageWidgetTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  *  Tests for the SRF\PageWidget class.

--- a/tests/phpunit/Unit/Formats/PrologTest.php
+++ b/tests/phpunit/Unit/Formats/PrologTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Prolog;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 class PrologTest extends QueryPrinterRegistryTestCase {
 

--- a/tests/phpunit/Unit/Formats/SparklineTest.php
+++ b/tests/phpunit/Unit/Formats/SparklineTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Sparkline class.

--- a/tests/phpunit/Unit/Formats/SpreadsheetTest.php
+++ b/tests/phpunit/Unit/Formats/SpreadsheetTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRF\SpreadsheetPrinter;
 
 /**

--- a/tests/phpunit/Unit/Formats/TagCloudTest.php
+++ b/tests/phpunit/Unit/Formats/TagCloudTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\TagCloud class.

--- a/tests/phpunit/Unit/Formats/TimeseriesTest.php
+++ b/tests/phpunit/Unit/Formats/TimeseriesTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Sparkline class.

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -5,7 +5,7 @@ namespace SRF\Test;
 use ExtensionRegistry;
 use MediaWiki\MediaWikiServices;
 use Parser;
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 use SMW\Tests\Utils\Mock\CoreMockObjectRepository;
 use SMW\Tests\Utils\Mock\MockObjectBuilder;
 use SMWQueryProcessor;

--- a/tests/phpunit/Unit/Formats/ValueRankTest.php
+++ b/tests/phpunit/Unit/Formats/ValueRankTest.php
@@ -2,8 +2,8 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
 use SMW\Tests\PHPUnitCompat;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRFValueRank;
 
 /**

--- a/tests/phpunit/Unit/Formats/jqPlotChartTest.php
+++ b/tests/phpunit/Unit/Formats/jqPlotChartTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\jqPlotChart class.

--- a/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
+++ b/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\jqPlotSeries class.

--- a/tests/phpunit/Unit/Formats/vCardTest.php
+++ b/tests/phpunit/Unit/Formats/vCardTest.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Test\QueryPrinterRegistryTestCase;
+use SMW\Tests\QueryPrinterRegistryTestCase;
 
 /**
  * Tests for the SRF\Gallery class.


### PR DESCRIPTION
This PR is related to the issue #882.

This PR contains:

- update composer.json - add `dev-master` to `require` section
- skip few tests for MW 1.40, new issue will be opened to check registration of parser function in MW 1.40
- update `ci.yml`
- fix paths in unit and integration tests
- enable codecov upload in MW 1.40

This PR also covers the issues #876 and #880.