### PR TITLE
Issue 889 - update composer.json, fix codecov upload and support for MW 1.40

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
 		"minus-x": "minus-x check ."
 	},
 	"require-dev": {
+		"mediawiki/semantic-media-wiki": "@dev",
 		"mediawiki/mediawiki-codesniffer": "43.0.0",
 		"mediawiki/minus-x": "1.1.3",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",


### PR DESCRIPTION
This PR is related to the issue #889.

This PR contains:

- `composer.json` updated
- `"mediawiki/semantic-media-wiki": "@dev"` added to `require-dev` section
- CI for MW 1.39 and 1.40 works as it should. 
- codecov upload works perfect, that is covered as a part of MW 1.40 