### PR TITLE
DateParser: Fix "str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated"

### DIFF
--- a/src/iCalendar/DateParser.php
+++ b/src/iCalendar/DateParser.php
@@ -30,7 +30,7 @@ class DateParser {
 		}
 
 		$year = number_format( $year, 0, '.', '' );
-		$time = str_replace( ':', '', $dataValue->getTimeString( false ) );
+		$time = str_replace( ':', '', $dataValue->getTimeString( false ) ?? '' );
 
 		// increment by one day, compute date to cover leap years etc.
 		if ( ( $time == false ) && ( $isEnd ) ) {


### PR DESCRIPTION
> Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/extensions/SemanticResultFormats/src/iCalendar/DateParser.php on line 33