### PR TITLE
make DataTables:getCellContent() a public function again

### DIFF
--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -878,7 +878,7 @@ class DataTables extends ResultPrinter {
 	/**
 	 * @see SMW\Query\ResultPrinters\TableResultPrinter
 	 */
-	private function getCellContent(
+	public function getCellContent(
 		string $label,
 		array $dataValues,
 		int $outputMode,


### PR DESCRIPTION
Refs: #918 