### PR TITLE
Remove unused addGlobalJSVariables()

### DIFF
--- a/SemanticResultFormats.hooks.php
+++ b/SemanticResultFormats.hooks.php
@@ -94,6 +94,7 @@ final class SRFHooks {
 	 * @return true
 	 */
 	public static function onResourceLoaderGetConfigVars( &$vars ) {
+		// Powers srf.settings.get(), via ext.stf.js.
 		$vars['srf-config'] = [
 			'version' => SRF_VERSION,
 			'settings' => [

--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -28,21 +28,6 @@ final class SRFUtils {
 	}
 
 	/**
-	 * Add JavaScript variables to the output
-	 *
-	 * @since 1.8
-	 */
-	public static function addGlobalJSVariables() {
-		$options = [
-			'srfgScriptPath' => $GLOBALS['srfgScriptPath'],
-			'srfVersion' => SRF_VERSION
-		];
-
-		$requireHeadItem = [ 'srf.options' => $options ];
-		SMWOutputs::requireHeadItem( 'srf.options', self::makeVariablesScript( $requireHeadItem ) );
-	}
-
-	/**
 	 * Returns semantic search link for the current query
 	 *
 	 * Generate a link to access the current ask query

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -147,9 +147,6 @@ class Gallery extends ResultPrinter {
 			$this->addImagePages( $results, $ig );
 		}
 
-		// SRF Global settings
-		SRFUtils::addGlobalJSVariables();
-
 		// Display a processing image as long as the DOM is no ready
 		if ( $this->params['widget'] !== '' ) {
 			$processing = SRFUtils::htmlProcessingElement();


### PR DESCRIPTION
* "srfVersion" is not used anywhere.

* "srfgScriptPath" used but never via mw.config.get().

  Instead, the onResourceLoaderGetConfigVars hook adds 'srf-config' (which includes a srfgScriptPath subkey) to mw.config.get(). Then, ext.stf.js uses this to implement srf.settings.get(), which is what various JavaScript files use to read srfgScriptPath.

  The global "srfgScriptPath" key is not used anywhere.