### PR TITLE
Fix template expansion to allow spaces in template names

### DIFF
--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -971,7 +971,7 @@ class DataTables extends ResultPrinter {
 			if ( $template ) {
 				// @fixme use named parameter ?
 				$titleTemplate = Title::makeTitle( NS_TEMPLATE,
-					Title::capitalize( $template, NS_TEMPLATE ) );
+					Title::capitalize( trim( $template ), NS_TEMPLATE ) );
 				$value_ = $this->expandTemplate( $titleTemplate, [ 1 => $value ] );
 				$value = Parser::stripOuterParagraph(
 					$this->parser->recursiveTagParseFully( $value_ )


### PR DESCRIPTION
Strict whitespace handling was recently introduced with #931

Trim to allow e.g. `|+template = mytemplate`

Alternatively, we could embrace the strictness, however docs should be updated:

https://www.semantic-mediawiki.org/wiki/Help:Datatables_format#Format_specific