### PR TITLE
Issue 954 - add graphfieldspages param to optionally include Page-type values as node fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            smw_version: dev-master
+            smw_version: 5.0.2
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -26,7 +26,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.40'
-            smw_version: dev-master
+            smw_version: 5.0.2
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -34,7 +34,7 @@ jobs:
             coverage: true
             experimental: false
           - mediawiki_version: '1.41'
-            smw_version: dev-master
+            smw_version: 5.0.2
             pf_version: 5.9
             sfs_version: dev-master
             php_version: 8.1
@@ -44,7 +44,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.42'
-            smw_version: dev-master
+            smw_version: 5.0.2
             pf_version: 5.9
             sfs_version: dev-master
             php_version: 8.1
@@ -54,7 +54,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.43.1'
-            smw_version: dev-master
+            smw_version: 5.0.2
             pf_version: 5.9
             sfs_version: dev-master
             php_version: 8.1

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ EXTENSION=SemanticResultFormats
 MW_VERSION?=1.39
 PHP_VERSION?=8.1
 DB_TYPE?=mysql
-DB_IMAGE?="mariadb:10"
+DB_IMAGE?="mariadb:11.2"
 
 # extensions
-SMW_VERSION?=dev-master
+SMW_VERSION ?= 5.0.2
 PF_VERSION ?= 5.5.1
 SFS_VERSION ?= 4.0.0-beta
 MM_VERSION ?= 6.0.1

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -95,7 +95,7 @@ class GraphFormatter {
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
 			$instance = $this;
-			$nodeLabel = htmlspecialchars( $node->getLabel(), ENT_QUOTES | ENT_XML1 );
+			$nodeLabel = htmlspecialchars( $node->getLabel() );
 
 			// take "displaytitle" as node-label if it is set
 			if ( $this->options->getNodeLabel() === GraphPrinter::NODELABEL_DISPLAYTITLE ) {
@@ -165,7 +165,7 @@ class GraphFormatter {
 			 *
 			 * @var \SRF\Graph\GraphNode $node
 			 */
-			$this->add( '"' . htmlspecialchars( $node->getID() ) . '"' );
+			$this->add( '"' . $node->getID() . '"' );
 
 			$inBrackets = [];
 			if ( $nodeLinkURL ) {
@@ -175,7 +175,7 @@ class GraphFormatter {
 				$inBrackets[] = 'label = ' . $nodeLabel;
 			}
 			if ( $nodeTooltip ) {
-				$inBrackets[] = 'tooltip = "' . htmlspecialchars( $nodeTooltip ) . '"';
+				$inBrackets[] = 'tooltip = "' .  $nodeTooltip  . '"';
 			}
 			if ( count( $inBrackets ) > 0 ) {
 				$this->add( ' [' . implode( ', ', $inBrackets ) . ']' );

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -137,14 +137,14 @@ class GraphFormatter {
 									. '<td align="' . $alignment . '"'
 										. (
 											$field['type'] === '_wpg'
-												? ' href="[[' . $field['valueLink'] . ']]">'
+												? ' href="[[' . htmlspecialchars( $field['valueLink'] ) . ']]">'
 													. $instance->getWordWrappedText(
-														$field['value'],
+														htmlspecialchars( $field['value'] ),
 														$instance->options->getWordWrapLimit()
 													)
 												: '>'
 													. $instance->getWordWrappedText(
-													$field['value'],
+													htmlspecialchars( $field['value'] ),
 													$instance->options->getWordWrapLimit()
 												)
 										)

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -165,7 +165,7 @@ class GraphFormatter {
 			 *
 			 * @var \SRF\Graph\GraphNode $node
 			 */
-			$this->add( '"' . $node->getID() . '"' );
+			$this->add( '"' . htmlspecialchars( $node->getID() ) . '"' );
 
 			$inBrackets = [];
 			if ( $nodeLinkURL ) {
@@ -175,7 +175,7 @@ class GraphFormatter {
 				$inBrackets[] = 'label = ' . $nodeLabel;
 			}
 			if ( $nodeTooltip ) {
-				$inBrackets[] = 'tooltip = "' . $nodeTooltip . '"';
+				$inBrackets[] = 'tooltip = "' . htmlspecialchars( $nodeTooltip ) . '"';
 			}
 			if ( count( $inBrackets ) > 0 ) {
 				$this->add( ' [' . implode( ', ', $inBrackets ) . ']' );
@@ -197,8 +197,8 @@ class GraphFormatter {
 
 					// handle parent/child switch (parentRelation)
 					$this->add( $this->options->getParentRelation()
-						? '"' . $parentNode['object'] . '" -> "' . $node->getID() . '"'
-						: '"' . $node->getID() . '" -> "' . $parentNode['object'] . '"' );
+						? '"' . htmlspecialchars( $parentNode['object'] ) . '" -> "' . htmlspecialchars( $node->getID() ) . '"'
+						: '"' . htmlspecialchars( $node->getID() ) . '" -> "' . htmlspecialchars( $parentNode['object'] ) . '"' );
 
 					if ( $this->options->isGraphLabel() || $this->options->isGraphColor() ) {
 						$this->add( ' [' );

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -175,7 +175,7 @@ class GraphFormatter {
 				$inBrackets[] = 'label = ' . $nodeLabel;
 			}
 			if ( $nodeTooltip ) {
-				$inBrackets[] = 'tooltip = "' .  $nodeTooltip  . '"';
+				$inBrackets[] = 'tooltip = "' . $nodeTooltip . '"';
 			}
 			if ( count( $inBrackets ) > 0 ) {
 				$this->add( ' [' . implode( ', ', $inBrackets ) . ']' );

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -95,7 +95,7 @@ class GraphFormatter {
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
 			$instance = $this;
-			$nodeLabel = htmlspecialchars( $node->getLabel() );
+			$nodeLabel = htmlspecialchars( $node->getLabel(), ENT_QUOTES | ENT_XML1 );
 
 			// take "displaytitle" as node-label if it is set
 			if ( $this->options->getNodeLabel() === GraphPrinter::NODELABEL_DISPLAYTITLE ) {
@@ -126,14 +126,29 @@ class GraphFormatter {
 								$alignment = in_array( $field['type'], [ '_num', '_qty', '_dat', '_tem' ] )
 									? 'right'
 									: 'left';
+								$valueLink = $field['valueLink'];
+								if ($valueLink !== null) {
+									$valueLink = $field['valueLink'];
+								} else {
+									$valueLink = $field['value'];
+								}
 								return '<tr><td align="left" href="[[Property:' . $field['page'] . ']]">'
 									. $field['name'] . '</td>'
-									. '<td align="' . $alignment . '">'
-										. $instance->getWordWrappedText(
-											$field['value'],
-											$instance->options->getWordWrapLimit()
+									. '<td align="' . $alignment . '"'
+										. (
+											$field['type'] === '_wpg'
+												? ' href="[[' . $field['valueLink'] . ']]">'
+													. $instance->getWordWrappedText(
+														$field['value'],
+														$instance->options->getWordWrapLimit()
+													)
+												: '>' 
+												    . $instance->getWordWrappedText(
+													$field['value'],
+													$instance->options->getWordWrapLimit()
+												)
 										)
-									. '</td></tr>';
+										. '</td></tr>';
 							}, $fields ) ) . "\n</table>\n>";
 				$nodeLinkURL = null;
 				// the value at the top is already hyperlinked.

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -127,7 +127,7 @@ class GraphFormatter {
 									? 'right'
 									: 'left';
 								$valueLink = $field['valueLink'];
-								if ($valueLink !== null) {
+								if ( $valueLink !== null ) {
 									$valueLink = $field['valueLink'];
 								} else {
 									$valueLink = $field['value'];
@@ -142,8 +142,8 @@ class GraphFormatter {
 														$field['value'],
 														$instance->options->getWordWrapLimit()
 													)
-												: '>' 
-												    . $instance->getWordWrappedText(
+												: '>'
+													. $instance->getWordWrappedText(
 													$field['value'],
 													$instance->options->getWordWrapLimit()
 												)

--- a/src/Graph/GraphNode.php
+++ b/src/Graph/GraphNode.php
@@ -35,6 +35,7 @@ class GraphNode {
 	 * @param string $value : Field value
 	 * @param string $type : Type of the field, for aligning
 	 * @param string $page : Property page
+	 * @param string|null $valueLink : The page to link the value to
 	 */
 	public function addField( $name, $value, $type, $page, $valueLink = null ) {
 		$this->fields[] = [ 'name' => $name ?: $page, 'value' => $value, 'type' => $type, 'page' => $page, 'valueLink' => $valueLink ];

--- a/src/Graph/GraphNode.php
+++ b/src/Graph/GraphNode.php
@@ -36,8 +36,8 @@ class GraphNode {
 	 * @param string $type : Type of the field, for aligning
 	 * @param string $page : Property page
 	 */
-	public function addField( $name, $value, $type, $page ) {
-		$this->fields[] = [ 'name' => $name ?: $page, 'value' => $value, 'type' => $type, 'page' => $page ];
+	public function addField( $name, $value, $type, $page, $valueLink = null ) {
+		$this->fields[] = [ 'name' => $name ?: $page, 'value' => $value, 'type' => $type, 'page' => $page, 'valueLink' => $valueLink ];
 	}
 
 	/**

--- a/src/Graph/GraphOptions.php
+++ b/src/Graph/GraphOptions.php
@@ -29,6 +29,7 @@ class GraphOptions {
 	private $showGraphLegend;
 	/** @var bool Show non-Page properties as fields within nodes rather than edges. */
 	private $showGraphFields;
+	private $showGraphFieldsPages;
 
 	public function __construct( $options ) {
 		$this->graphName = trim( $options['graphname'] );
@@ -45,6 +46,7 @@ class GraphOptions {
 		$this->showGraphColor = trim( $options['graphcolor'] );
 		$this->showGraphLegend = trim( $options['graphlegend'] );
 		$this->showGraphFields = trim( $options['graphfields'] );
+		$this->showGraphFieldsPages = trim( $options['graphfieldspages'] );
 	}
 
 	public function getGraphName(): string {
@@ -103,5 +105,9 @@ class GraphOptions {
 
 	public function showGraphFields(): bool {
 		return $this->showGraphFields;
+	}
+
+	public function showGraphFieldsPages(): string {
+		return $this->showGraphFieldsPages;
 	}
 }

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -242,10 +242,17 @@ class GraphPrinter extends ResultPrinter {
 						$node = new GraphNode( $objectText );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
 					} elseif ( $node && $objectText !== $node->getId() ) {
-						$parents[] = [
-							'predicate' => $label,
-							'object' => $objectText,
-						];
+						if ( ( $pageTypeSeen !== 2 && $isPageType ) ) {
+							$parents[] = [
+								'predicate' => $label,
+								'object' => $object->getDisplayTitle(),
+							];
+						} else {
+							$parents[] = [
+								'predicate' => $label,
+								'object' => $objectText,
+							];
+						}
 					}
 					continue;
 				}
@@ -284,16 +291,20 @@ class GraphPrinter extends ResultPrinter {
 
 		if ( $node ) {
 			foreach ( $parents as $parent ) {
-				$node->addParentNode( $parent['predicate'], $parent['object'] );
+				if ( !empty( $parent['object'] ) ) {
+					$node->addParentNode( $parent['predicate'], $parent['object'] );
+				}
 			}
 			foreach ( $fields as $field ) {
-				$node->addField(
-					$field['name'],
-					$field['value'],
-					$field['type'],
-					$field['page'],
-					$field['valueLink'] ?? null
-				);
+				if ( $field['value'] !== '' ) {
+					$node->addField(
+						$field['name'],
+						$field['value'],
+						$field['type'],
+						$field['page'],
+						$field['valueLink'] ?? null
+					);
+				}
 			}
 			$this->nodes[] = $node;
 		}

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -192,51 +192,110 @@ class GraphPrinter extends ResultPrinter {
 		$node = null;
 		$fields = [];
 		$parents = [];
-		// loop through all row fields
+		$pageTypeSeen = 0;
+
 		foreach ( $row as $result_array ) {
 			$request = $result_array->getPrintRequest();
 			$type = $request->getTypeID();
-			// Whether this printout should be shown as an edge.
-			// no fields at all.
-			$show_as_edge = !$this->options->showGraphFields()
-				|| in_array( $type, self::PAGETYPES )
+			$isPageType = in_array( $type, self::PAGETYPES );
+			$canonicalLabel = $request->getCanonicalLabel();
+			$label = $request->getLabel() ?: $canonicalLabel ?: '?';
+
+			if ( $isPageType ) {
+				$pageTypeSeen++;
+			}
+
+			$showAsEdge = !$this->options->showGraphFields()
+				|| $isPageType
 				|| $request->isMode( PrintRequest::PRINT_CHAIN );
 
-			// Loop through all values of a multivalue field.
+			$showGraphFieldsPages = $this->options->showGraphFieldsPages() === 'yes';
+			$showGraphFields = $this->options->showGraphFields();
+
 			while ( ( $object = $result_array->getNextDataValue() ) !== false ) {
-				if ( $show_as_edge ) {
-					if ( !$node && !$object->getProperty() ) {
-						// The graph node for the current record has not been created,
-						// and this is the printout '?'. So, create it now.
-						$node = new GraphNode( $object->getShortWikiText() );
+				$hasProperty = $object->getProperty();
+				$objectText = $object->getShortWikiText();
+
+				$includeAsEdge = !$showGraphFields || $isPageType || $request->isMode( PrintRequest::PRINT_CHAIN );
+				$includeAsField = $showGraphFields && ( !$isPageType || $showGraphFieldsPages );
+
+				$skipNode = $isPageType && $pageTypeSeen > 1;
+
+				// Create node if not yet created
+				if ( !$node && !$hasProperty && !$skipNode ) {
+					$node = new GraphNode( $objectText );
+					$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
+				}
+
+				// Handle edge
+				if ( $showGraphFieldsPages ) {
+					if ( $includeAsEdge && $node ) {
+						if ( $objectText !== $node->getId() && $pageTypeSeen === 2 ) {
+							$parents[] = [
+								'predicate' => $label,
+								'object' => $objectText,
+							];
+						}
+					}
+				} elseif ( $showAsEdge ) {
+					if ( !$node && !$hasProperty ) {
+						$node = new GraphNode( $objectText );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
-					} else {
-						// Remember a parent node to add after the row is processed.
+					} elseif ( $node && $objectText !== $node->getId() ) {
 						$parents[] = [
-							'predicate' => $request->getLabel(),
-							'object' => $object->getShortWikiText()
+							'predicate' => $label,
+							'object' => $objectText,
 						];
 					}
-				} else {
-					// A non-Page property and 'graphfields' is set,
-					// so display it as a field after the row has been processed.
+					continue;
+				}
+
+				// Handle field
+				if ( $showGraphFieldsPages && $includeAsField ) {
+					if ( $hasProperty || !$isPageType ) {
+						// non-page or property field
+						if ( $pageTypeSeen !== 2 && !$isPageType ) {
+							$fields[] = [
+								'name' => $label,
+								'value' => $objectText,
+								'type' => $type,
+								'page' => $canonicalLabel,
+							];
+						}
+						// page field
+						elseif ( $pageTypeSeen !== 2 && $isPageType ) {
+							$fields[] = [
+								'name' => $label,
+								'value' => $object->getDisplayTitle(),
+								'valueLink' => $objectText,
+								'type' => $type,
+								'page' => $canonicalLabel,
+							];
+						}
+					}
+				} elseif ( !$showGraphFieldsPages && !$showAsEdge ) {
 					$fields[] = [
-						'name' => $request->getLabel(),
-						'value' => $object->getShortWikiText(),
+						'name' => $label,
+						'value' => $objectText,
 						'type' => $type,
-						'page' => $request->getCanonicalLabel()
+						'page' => $canonicalLabel,
 					];
 				}
 			}
 		}
-		// Add the node, if any, its parent nodes and fields for non-Page properties to the current edge.
+
 		if ( $node ) {
 			foreach ( $parents as $parent ) {
 				$node->addParentNode( $parent['predicate'], $parent['object'] );
-				// @TODO: add explicit nodes with hyperlinks to every parent node not added as '?', but only once.
 			}
 			foreach ( $fields as $field ) {
-				$node->addField( $field['name'], $field['value'], $field['type'], $field['page'] );
+				$node->addField(
+					$field['name'],
+					$field['value'],
+					$field['type'],
+					$field['page'],
+					$field['valueLink'] ?? null
+				);
 			}
 			$this->nodes[] = $node;
 		}
@@ -342,6 +401,12 @@ class GraphPrinter extends ResultPrinter {
 			'message' => 'srf-paramdesc-graphfields',
 			'manipluatedefault' => false,
 			'type' => 'boolean'
+		];
+
+		$params['graphfieldspages'] = [
+			'default' => 'no',
+			'message' => 'srf-paramdesc-graphfieldspages',
+			'type' => 'string'
 		];
 
 		return $params;

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -261,9 +261,7 @@ class GraphPrinter extends ResultPrinter {
 								'type' => $type,
 								'page' => $canonicalLabel,
 							];
-						}
-						// page field
-						elseif ( $pageTypeSeen !== 2 && $isPageType ) {
+						} elseif ( $pageTypeSeen !== 2 && $isPageType ) {
 							$fields[] = [
 								'name' => $label,
 								'value' => $object->getDisplayTitle(),

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -214,7 +214,11 @@ class GraphPrinter extends ResultPrinter {
 
 			while ( ( $object = $result_array->getNextDataValue() ) !== false ) {
 				$hasProperty = $object->getProperty();
-				$objectText = $object->getShortWikiText();
+				if ( $object instanceof \SMW\DataValues\StringValue ) {
+					$objectText = $object->getShortWikiText();
+				} else {
+					$objectText = $object->getDisplayTitle();
+				}
 
 				$includeAsEdge = !$showGraphFields || $isPageType || $request->isMode( PrintRequest::PRINT_CHAIN );
 				$includeAsField = $showGraphFields && ( !$isPageType || $showGraphFieldsPages );
@@ -242,17 +246,10 @@ class GraphPrinter extends ResultPrinter {
 						$node = new GraphNode( $objectText );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
 					} elseif ( $node && $objectText !== $node->getId() ) {
-						if ( ( $pageTypeSeen !== 2 && $isPageType ) ) {
-							$parents[] = [
-								'predicate' => $label,
-								'object' => $object->getDisplayTitle(),
-							];
-						} else {
-							$parents[] = [
-								'predicate' => $label,
-								'object' => $objectText,
-							];
-						}
+						$parents[] = [
+							'predicate' => $label,
+							'object' => $objectText,
+						];
 					}
 					continue;
 				}

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -269,7 +269,7 @@ class GraphPrinter extends ResultPrinter {
 							$fields[] = [
 								'name' => $label,
 								'value' => $object->getDisplayTitle(),
-								'valueLink' => $objectText,
+								'valueLink' => $object->getShortWikiText(),
 								'type' => $type,
 								'page' => $canonicalLabel,
 							];

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -20,7 +20,7 @@ class GraphFormatterTest extends \PHPUnit\Framework\TestCase {
 	private $cases = [
 		'Simple' => [
 			// @see https://www.semantic-mediawiki.org/wiki/Help:Graph_format
-			'params' => [ 'graphfields' => false ],
+			'params' => [ 'graphfields' => false, 'graphfieldspages' => 'no' ],
 			'nodes' => [
 				[ 'name' => 'Team:Alpha', 'label' => 'Alpha', 'parents' => [
 					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ]
@@ -112,6 +112,7 @@ FIELDS
 		'graphlabel' => true,
 		'graphcolor' => true,
 		'graphlegend' => true,
+		'graphfieldspages' => 'no'
 	];
 
 	/**

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -56,14 +56,14 @@ SIMPLE
 				[ 'name' => 'Team:Alpha', 'label' => 'Alpha', 'parents' => [
 					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ]
 				], 'fields' => [
-					[ 'name' => 'Rated as', 'value' => 10, 'type' => '_num', 'page' => 'Rating' ]
+					[ 'name' => 'Rated as', 'value' => 10, 'type' => '_num', 'page' => 'Rating', 'valueLink' => null ]
 				] ],
 				[ 'name' => 'Team:Beta', 'label' => 'Beta', 'parents' => [
 					[ 'predicate' => 'Casted', 'object' => 'Person:Sebastian Schmid' ],
 					[ 'predicate' => 'Casted', 'object' => 'Person:Alexander Gesinn' ],
 					[ 'predicate' => 'Part of Team', 'object' => 'Team:Alpha' ],
 				], 'fields' => [
-					[ 'name' => 'Rated as', 'value' => 20, 'type' => '_num', 'page' => 'Rating' ]
+					[ 'name' => 'Rated as', 'value' => 20, 'type' => '_num', 'page' => 'Rating', 'valueLink' => null ]
 				] ]
 			],
 			'legend' => '<div class="graphlegend">' .
@@ -93,6 +93,32 @@ size="100";node [shape=rect];rankdir=LR;
 "Team:Alpha" -> "Team:Beta" [label="Part of Team",fontcolor=red,arrowhead=diamond,color=red];
 }
 FIELDS
+		],
+		'graphfieldspages=yes - Only first page field becomes node' => [
+			'params' => [ 'graphfields' => true, 'graphfieldspages' => 'yes' ],
+			'nodes' => [
+				[ 'name' => 'Team:Gamma', 'label' => 'Gamma', 'parent' => [], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ]
+			],
+			'legend' => '<div class="graphlegend"></div>',
+			'dot' => <<<'DOT'
+digraph "Unit Test" {graph [fontsize=10, fontname="Verdana"]
+node [fontsize=10, fontname="Verdana"];
+edge [fontsize=10, fontname="Verdana"];
+size="100";node [shape=rect];rankdir=LR;
+"Team:Gamma" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Gamma]]">Gamma</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Gamma"];
+}
+DOT
 		]
 	];
 
@@ -133,7 +159,7 @@ FIELDS
 			}
 			if ( isset( $node['fields'] ) ) {
 				foreach ( $node['fields'] as $field ) {
-					$graph_node->addField( $field['name'], $field['value'], $field['type'], $field['page'] );
+					$graph_node->addField( $field['name'], $field['value'], $field['type'], $field['page'], $field['valueLink'] );
 				}
 			}
 			$nodes[] = $graph_node;

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -119,6 +119,100 @@ size="100";node [shape=rect];rankdir=LR;
 >, tooltip = "Gamma"];
 }
 DOT
+		],
+		// @see https://www.php.net/manual/en/function.htmlspecialchars.php
+		'graphfieldspages=yes - with parent nodes and special chars' => [
+			'params' => [ 'graphfields' => true, 'graphfieldspages' => 'yes' ],
+			'nodes' => [
+				[ 'name' => 'Team:Delta', 'label' => 'Delta', 'parents' => [
+					[ 'predicate' => 'Part of Team', 'object' => 'Solar & Hydro' ]
+				], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ],
+				[ 'name' => 'Team:Epsilon', 'label' => 'Epsilon', 'parents' => [
+					[ 'predicate' => 'Part of Team', 'object' => 'Solar < Hydro' ]
+				], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ],
+				[ 'name' => 'Team:Zeta', 'label' => 'Zeta', 'parents' => [
+					[ 'predicate' => 'Part of Team', 'object' => 'Solar > Hydro' ]
+				], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ],
+				[ 'name' => 'Team:Eta', 'label' => 'Eta', 'parents' => [
+					[ 'predicate' => 'Part of Team', 'object' => 'Solar "" Hydro' ]
+				], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ],
+				[ 'name' => 'Team:Theta', 'label' => 'Theta', 'parents' => [
+					[ 'predicate' => 'Part of Team', 'object' => 'Solar \' Hydro' ]
+				], 'fields' => [
+					[ 'name' => 'Main Category', 'value' => 'Team', 'type' => '_wpg', 'page' => 'Main Category', 'valueLink' => 'Team' ],
+					[ 'name' => 'Casted', 'value' => 'Sebastian Schmid', 'type' => '_wpg', 'page' => 'Casted', 'valueLink' => 'Sebastian Schmid' ],
+					[ 'name' => 'Team Code', 'value' => 'ES', 'type' => '_txt', 'page' => 'Team Code', 'valueLink' => null ],
+				] ]
+			],
+			'legend' => '<div class="graphlegend"><div class="graphlegenditem" style="color: black">black: Part of Team</div></div>',
+			'dot' => <<<'DOT'
+digraph "Unit Test" {graph [fontsize=10, fontname="Verdana"]
+node [fontsize=10, fontname="Verdana"];
+edge [fontsize=10, fontname="Verdana"];
+size="100";node [shape=rect];rankdir=LR;
+"Team:Delta" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Delta]]">Delta</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Delta"];
+"Team:Epsilon" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Epsilon]]">Epsilon</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Epsilon"];
+"Team:Zeta" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Zeta]]">Zeta</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Zeta"];
+"Team:Eta" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Eta]]">Eta</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Eta"];
+"Team:Theta" [label = <
+<table border="0" cellborder="0" cellspacing="1" columns="*" rows="*">
+<tr><td colspan="2" href="[[Team:Theta]]">Theta</td></tr><hr/>
+<tr><td align="left" href="[[Property:Main Category]]">Main Category</td><td align="left" href="[[Team]]">Team</td></tr>
+<tr><td align="left" href="[[Property:Casted]]">Casted</td><td align="left" href="[[Sebastian Schmid]]">Sebastian Schmid</td></tr>
+<tr><td align="left" href="[[Property:Team Code]]">Team Code</td><td align="left">ES</td></tr>
+</table>
+>, tooltip = "Theta"];
+"Solar &amp; Hydro" -> "Team:Delta" [label="Part of Team",fontcolor=black,arrowhead=diamond,color=black];
+"Solar &lt; Hydro" -> "Team:Epsilon" [label="Part of Team",fontcolor=black,arrowhead=diamond,color=black];
+"Solar &gt; Hydro" -> "Team:Zeta" [label="Part of Team",fontcolor=black,arrowhead=diamond,color=black];
+"Solar &quot;&quot; Hydro" -> "Team:Eta" [label="Part of Team",fontcolor=black,arrowhead=diamond,color=black];
+"Solar &#039; Hydro" -> "Team:Theta" [label="Part of Team",fontcolor=black,arrowhead=diamond,color=black];
+}
+DOT
 		]
 	];
 


### PR DESCRIPTION
This PR is related to the issue #954.

Currently, when using `graphfields=yes`, only `non-Page` properties (e.g., strings, dates) are displayed in the graph node info table.
This PR introduces a new optional parameter `graphfieldspages=` with the following behavior:
- When `graphfieldspages=no` (default):
    - All Page-type properties are rendered as graph nodes (edges), and none appear as node fields.

- When `graphfieldspages=yes`:
    - For each Page-type property per node:
        - The first Page property is rendered only as a node (edge), not as a field.
        - Any additional Page properties are rendered only as fields in the node info table, not as separate nodes.
 
This PR also:
- Adds a test case to verify the new behavior of `graphfieldspages`.
- Updates the CI configuration to use the latest stable version of SMW instead of the `dev-master` branch.