### PR TITLE
Fix issue #966 class Html not found with mediawiki 1.44

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -1,5 +1,7 @@
 <?php
+
 use MediaWiki\Html\Html;
+
 /**
  * Common libray of independent functions that are shared among different printers
  * @license GPL-2.0-or-later

--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -1,5 +1,5 @@
 <?php
-
+use MediaWiki\Html\Html;
 /**
  * Common libray of independent functions that are shared among different printers
  * @license GPL-2.0-or-later

--- a/formats/calendar/EventCalendar.php
+++ b/formats/calendar/EventCalendar.php
@@ -2,7 +2,7 @@
 
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 


### PR DESCRIPTION
Fix issue #966