### PR TITLE
Add explicit return types and Linker import in TreeResultPrinter for SMW compatibility

### DIFF
--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -10,6 +10,7 @@ namespace SRF\Formats\Tree;
 
 use Exception;
 use Html;
+use MediaWiki\Linker\Linker;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\QueryResult;
@@ -37,7 +38,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * (non-PHPdoc)
 	 * @see \SMW\Query\ResultPrinters\ResultPrinter::getName()
 	 */
-	public function getName() {
+	public function getName(): string {
 		// Give grep a chance to find the usages:
 		// srf-printername-tree, srf-printername-ultree, srf-printername-oltree
 		return \Message::newFromKey( 'srf-printername-' . $this->mFormat )->text();
@@ -65,7 +66,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	/**
 	 * @see ResultPrinter::postProcessParameters()
 	 */
-	protected function postProcessParameters() {
+	protected function postProcessParameters(): void {
 		parent::postProcessParameters();
 
 		// Don't support pagination in trees
@@ -164,7 +165,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @return array of IParamDefinition|array
 	 * @throws Exception
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['parent'] = [
@@ -258,7 +259,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 *
 	 * @return \Linker
 	 */
-	public function getLinker( $firstcol = false ) {
+	public function getLinker( $firstcol = false ): ?Linker {
 		return $this->mLinker;
 	}
 
@@ -358,7 +359,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @param string $msgkey
 	 * @param string | string[] $params
 	 */
-	protected function addError( $msgkey, $params = [] ) {
+	protected function addError( $msgkey, $params = [] ): void {
 		parent::addError(
 			\Message::newFromKey( $msgkey )
 				->params( $params )


### PR DESCRIPTION
This updates TreeResultPrinter to match typed method signatures now present in SMW parent classes. Closes #6581

Changes:
- add string return type to getName()
- add array return type to getParamDefinitions()
- add void return type to postProcessParameters()
- add ?Linker return type to getLinker()
- add use MediaWiki\Linker\Linker

Why:
Without these changes, PHP fatal errors occur because TreeResultPrinter overrides no longer match the corresponding SMW parent method signatures.

Scope:
This is intended as a compatibility fix only. No tree-format logic was changed.