### PR TITLE
Add CI for MW 1.43+ and remove MW 1.39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            smw_version: 5.1.0
+          - mediawiki_version: '1.43'
+            smw_version: 6.0.1
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -34,6 +34,22 @@ jobs:
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
+            experimental: false
+          - mediawiki_version: '1.44'
+            smw_version: 6.0.1
+            php_version: 8.2
+            mm_version: 6.0.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.45'
+            smw_version: master
+            php_version: 8.1
+            mm_version: 6.0.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
             experimental: false
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.45'
-            smw_version: master
+            smw_version: dev-master
             php_version: 8.3
             mm_version: 6.0.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.43'
-            smw_version: dev-master
+            smw_version: 6.0.1
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -26,7 +26,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
-            smw_version: dev-master
+            smw_version: 6.0.1
             pf_version: 5.9
             sfs_version: 4.0.0-beta
             php_version: 8.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.45'
             smw_version: master
-            php_version: 8.1
+            php_version: 8.3
             mm_version: 6.0.1
             database_type: mysql
             database_image: "mariadb:11.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.43'
-            smw_version: 6.0.1
+            smw_version: dev-master
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -26,7 +26,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
-            smw_version: 6.0.1
+            smw_version: dev-master
             pf_version: 5.9
             sfs_version: 4.0.0-beta
             php_version: 8.3
@@ -36,7 +36,7 @@ jobs:
             coverage: true
             experimental: false
           - mediawiki_version: '1.44'
-            smw_version: 6.0.1
+            smw_version: dev-master
             php_version: 8.2
             mm_version: 6.0.1
             database_type: mysql

--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Html\Html;
+
 /**
  * Common libray of independent functions that are shared among different printers
  * @license GPL-2.0-or-later

--- a/extension.json
+++ b/extension.json
@@ -14,9 +14,9 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39",
+		"MediaWiki": ">= 1.43",
 		"extensions": {
-			"SemanticMediaWiki": ">= 4.2"
+			"SemanticMediaWiki": ">= 6.0"
 		}
 	},
 	"MessagesDirs": {

--- a/formats/Gantt/GanttPrinter.php
+++ b/formats/Gantt/GanttPrinter.php
@@ -32,7 +32,7 @@ class GanttPrinter extends ResultPrinter {
 		return wfMessage( 'srf-printername-gantt' )->text();
 	}
 
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params[] = [
@@ -106,7 +106,7 @@ class GanttPrinter extends ResultPrinter {
 	 *
 	 * @see ResultPrinter::handleParameters()
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		// Set header params
 		$this->params['title'] = trim( $params['diagramtitle'] );
 		$this->params['axisformat'] = trim( $params['axisformat'] );

--- a/formats/Gantt/GanttPrinter.php
+++ b/formats/Gantt/GanttPrinter.php
@@ -16,7 +16,7 @@
 
 namespace SRF\Gantt;
 
-use Html;
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 use SMWDIBlob;

--- a/formats/JitGraph/SRF_JitGraph.php
+++ b/formats/JitGraph/SRF_JitGraph.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Title\Title;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 

--- a/formats/JitGraph/SRF_JitGraph.php
+++ b/formats/JitGraph/SRF_JitGraph.php
@@ -62,7 +62,7 @@ class SRFJitGraph extends ResultPrinter {
 
 	protected $debug_out = '';
 
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		if ( array_key_exists( 'graphname', $params ) ) {
@@ -314,7 +314,7 @@ class SRFJitGraph extends ResultPrinter {
 	}
 
 	protected function includeJS() {
-		SMWOutputs::requireHeadItem( SMW_HEADER_STYLE );
+		SMWOutputs::requireStyle( 'ext.smw.styles' );
 
 		// $wgOut->addModules( 'ext.srf.jitgraph' );
 
@@ -351,7 +351,7 @@ class SRFJitGraph extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['graphname'] = [

--- a/formats/Prolog/PrologPrinter.php
+++ b/formats/Prolog/PrologPrinter.php
@@ -59,7 +59,7 @@ class PrologPrinter extends FileExportPrinter {
 	 *
 	 * @return string
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		return ( $this->params[ 'filename' ] ?: base_convert( uniqid(), 16, 36 ) ) . $this->fileFormat[ 'extension' ];
 	}
 
@@ -69,7 +69,7 @@ class PrologPrinter extends FileExportPrinter {
 	 * @param QueryResult $queryResult
 	 * @param array $params
 	 */
-	public function outputAsFile( QueryResult $queryResult, array $params ) {
+	public function outputAsFile( QueryResult $queryResult, array $params ): void {
 		if ( array_key_exists( 'fileformat', $params ) && array_key_exists( $params[ 'fileformat' ]->getValue(), $this->fileFormats ) ) {
 			$this->fileFormat = $this->fileFormats[ $params[ 'fileformat' ]->getValue() ];
 		} else {
@@ -87,7 +87,7 @@ class PrologPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$definitions[ 'searchlabel' ]->setDefault( wfMessage( 'srf-prolog-link' )->inContentLanguage()->text() );

--- a/formats/array/SRF_Array.php
+++ b/formats/array/SRF_Array.php
@@ -354,7 +354,7 @@ class SRFArray extends ResultPrinter {
 		return $text;
 	}
 
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		// does the link parameter:
 		parent::handleParameters( $params, $outputmode );
 
@@ -417,7 +417,7 @@ class SRFArray extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		### adjusted basic SMW params: ###

--- a/formats/array/SRF_Hash.php
+++ b/formats/array/SRF_Hash.php
@@ -67,7 +67,7 @@ class SRFHash extends SRFArray {
 		return true;
 	}
 
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 		$this->mShowPageTitles = true;
 	}
@@ -81,7 +81,7 @@ class SRFHash extends SRFArray {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 		// page title is Hash key, otherwise, just use Array format!
 		unset( $params['pagetitle'] );

--- a/formats/boilerplate/SRF_Boilerplate.php
+++ b/formats/boilerplate/SRF_Boilerplate.php
@@ -281,7 +281,7 @@ class SRFBoilerplate extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		// Add your parameters here

--- a/formats/boilerplate/SRF_Boilerplate.php
+++ b/formats/boilerplate/SRF_Boilerplate.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/calendar/EventCalendar.php
+++ b/formats/calendar/EventCalendar.php
@@ -2,7 +2,7 @@
 
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 

--- a/formats/calendar/EventCalendar.php
+++ b/formats/calendar/EventCalendar.php
@@ -43,7 +43,7 @@ class EventCalendar extends ResultPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['defaultview'] = [

--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -37,7 +37,7 @@ class SRFCalendar extends ResultPrinter {
 		$this->mColors = $colors;
 	}
 
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->mTemplate = trim( $params['template'] );
@@ -657,7 +657,7 @@ END;
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['lang'] = [

--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -4,6 +4,7 @@ $wgAutoloadClasses['SRFCHistoricalDate'] = __DIR__
 	. '/SRFC_HistoricalDate.php';
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/carousel/Carousel.php
+++ b/formats/carousel/Carousel.php
@@ -37,7 +37,7 @@ class Carousel extends ResultPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['width'] = [

--- a/formats/carousel/Carousel.php
+++ b/formats/carousel/Carousel.php
@@ -8,8 +8,9 @@
  */
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 
@@ -429,7 +430,7 @@ class Carousel extends ResultPrinter {
 		$parser = MediaWikiServices::getInstance()->getParser();
 		$items = [];
 		foreach ( $data['query']['result']['results'] as $titleText => $value ) {
-			$title_ = \Title::newFromText( $titleText );
+			$title_ = Title::newFromText( $titleText );
 			$captions = [];
 			$titles = [];
 			$images = [];
@@ -630,7 +631,7 @@ class Carousel extends ResultPrinter {
 			return null;
 		}
 
-		$title = \Title::newFromText( $value['fulltext'], NS_FILE );
+		$title = Title::newFromText( $value['fulltext'], NS_FILE );
 		$wikiFilePage = new \WikiFilePage( $title );
 		$file = $wikiFilePage->getFile();
 

--- a/formats/d3/SRF_D3Chart.php
+++ b/formats/d3/SRF_D3Chart.php
@@ -108,7 +108,7 @@ class SRFD3Chart extends AggregatablePrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['min'] = [

--- a/formats/d3/SRF_D3Chart.php
+++ b/formats/d3/SRF_D3Chart.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\ResultPrinters\AggregatablePrinter;
 
 /**

--- a/formats/dataframe/DataframePrinter.php
+++ b/formats/dataframe/DataframePrinter.php
@@ -55,7 +55,7 @@ class DataframePrinter extends FileExportPrinter {
 	 *
 	 * @return string
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		return ( $this->params[ 'filename' ] ?: base_convert( uniqid(), 16, 36 ) ) . $this->fileFormat[ 'extension' ];
 	}
 
@@ -65,7 +65,7 @@ class DataframePrinter extends FileExportPrinter {
 	 * @param QueryResult $queryResult
 	 * @param array $params
 	 */
-	public function outputAsFile( QueryResult $queryResult, array $params ) {
+	public function outputAsFile( QueryResult $queryResult, array $params ): void {
 		$this->fileFormat = $this->fileFormats[ 'R' ];
 		parent::outputAsFile( $queryResult, $params );
 	}
@@ -76,7 +76,7 @@ class DataframePrinter extends FileExportPrinter {
 	 *
 	 * @return array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$definitions[ 'searchlabel' ]->setDefault( wfMessage( 'srf-dataframe-link' )->inContentLanguage()->text() );

--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -12,7 +12,7 @@
 
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use Mediawiki\Title\Title;
 use MWException;

--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -244,7 +244,7 @@ class SRFDygraphs extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['datasource'] = [

--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\DIWikiPage;

--- a/formats/dygraphs/SRF_Dygraphs.php
+++ b/formats/dygraphs/SRF_Dygraphs.php
@@ -1,6 +1,7 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\DIWikiPage;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
@@ -151,7 +152,7 @@ class SRFDygraphs extends ResultPrinter {
 		return $aggregatedValues;
 	}
 
-	private function makePageFromTitle( \Title $title ) {
+	private function makePageFromTitle( Title $title ) {
 		$dataValue = new SMWWikiPageValue( '_wpg' );
 		$dataItem = DIWikiPage::newFromTitle( $title );
 		$dataValue->setDataItem( $dataItem );

--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -10,7 +10,7 @@
 namespace SRF\Filtered;
 
 use Exception;
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use SMW\DataValues\PropertyValue;
 use SMW\Localizer\Message;

--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -11,6 +11,7 @@ namespace SRF\Filtered;
 
 use Exception;
 use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
 use MediaWiki\MediaWikiServices;
 use SMW\DataValues\PropertyValue;
 use SMW\Localizer\Message;
@@ -143,7 +144,7 @@ class Filtered extends ResultPrinter {
 	 * @param array $params
 	 * @param $outputMode
 	 */
-	protected function handleParameters( array $params, $outputMode ) {
+	protected function handleParameters( array $params, $outputMode ): void {
 		parent::handleParameters( $params, $outputMode );
 
 		// // Set in ResultPrinter:
@@ -233,7 +234,7 @@ class Filtered extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params[] = [
@@ -265,7 +266,7 @@ class Filtered extends ResultPrinter {
 		return $params;
 	}
 
-	public function getLinker( $firstcol = false, $force = false ) {
+	public function getLinker( $firstcol = false, $force = false ): ?Linker {
 		return ( $force ) ? $this->mLinker : parent::getLinker( $firstcol );
 	}
 
@@ -292,7 +293,7 @@ class Filtered extends ResultPrinter {
 		call_user_func( $setter, 'srf-filtered-config', $previousConfig );
 
 		if ( $parserOutput ) {
-				$parserOutput->addJsConfigVars( 'srfFilteredConfig', $previousConfig );
+				$parserOutput->setJsConfigVar( 'srfFilteredConfig', $previousConfig );
 		}
 	}
 
@@ -326,7 +327,7 @@ class Filtered extends ResultPrinter {
 		return $resultAsArray;
 	}
 
-	public function addError( $errorMessage ) {
+	public function addError( $errorMessage ): void {
 		parent::addError( $errorMessage );
 	}
 

--- a/formats/filtered/src/View/CalendarView.php
+++ b/formats/filtered/src/View/CalendarView.php
@@ -116,7 +116,7 @@ class CalendarView extends View {
 	/**
 	 * Transfers the parameters applicable to this view into internal variables.
 	 */
-	protected function handleParameters() {
+	protected function handleParameters(): void {
 		$params = $this->getActualParameters();
 		$parser = $this->getQueryPrinter()->getParser();
 

--- a/formats/filtered/src/View/ListView.php
+++ b/formats/filtered/src/View/ListView.php
@@ -40,7 +40,7 @@ class ListView extends View {
 	/**
 	 * Transfers the parameters applicable to this view into internal variables.
 	 */
-	protected function handleParameters() {
+	protected function handleParameters(): void {
 		$params = $this->getActualParameters();
 		$this->params = $params;
 

--- a/formats/filtered/src/View/MapView.php
+++ b/formats/filtered/src/View/MapView.php
@@ -5,6 +5,7 @@ namespace SRF\Filtered\View;
 use DataValues\Geo\Parsers\LatLongParser;
 use Exception;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\DataValues\PropertyValue;
 use SRF\Filtered\ResultItem;
 
@@ -306,7 +307,7 @@ class MapView extends View {
 			}
 
 			$file = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle(
-				\Title::newFromText( $icon, NS_FILE )
+				Title::newFromText( $icon, NS_FILE )
 			)->getFile();
 
 			if ( $file->exists() ) {

--- a/formats/filtered/src/View/TableView.php
+++ b/formats/filtered/src/View/TableView.php
@@ -11,12 +11,12 @@ namespace SRF\Filtered\View;
  * @ingroup SemanticResultFormats
  */
 
-use Html;
+use MediaWiki\Html\Html;
+use MediaWiki\Xml\Xml;
 use Message;
 use SMW\Query\PrintRequest;
 use SMW\Query\Result\ResultArray;
 use SRF\Filtered\ResultItem;
-use Xml;
 
 /**
  * The TableView class defines the Table view.

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -2,15 +2,15 @@
 
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 use SMWDataItem;
 use SMWOutputs;
 use SRFUtils;
-use Title;
 use TraditionalImageGallery;
 
 /**

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -435,7 +435,7 @@ class Gallery extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['class'] = [

--- a/formats/googlecharts/SRF_GoogleBar.php
+++ b/formats/googlecharts/SRF_GoogleBar.php
@@ -17,7 +17,7 @@ class SRFGoogleBar extends ResultPrinter {
 	 * (non-PHPdoc)
 	 * @see ResultPrinter::handleParameters()
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->m_width = $this->params['width'];
@@ -89,7 +89,7 @@ class SRFGoogleBar extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['width'] = [

--- a/formats/googlecharts/SRF_GooglePie.php
+++ b/formats/googlecharts/SRF_GooglePie.php
@@ -18,7 +18,7 @@ class SRFGooglePie extends ResultPrinter {
 	 * (non-PHPdoc)
 	 * @see ResultPrinter::handleParameters()
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->m_width = $this->params['width'];
@@ -81,7 +81,7 @@ class SRFGooglePie extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['height'] = [

--- a/formats/graphviz/SRF_Process.php
+++ b/formats/graphviz/SRF_Process.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Title\Title;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 

--- a/formats/graphviz/SRF_Process.php
+++ b/formats/graphviz/SRF_Process.php
@@ -67,7 +67,7 @@ class SRFProcess extends ResultPrinter {
 	 * (non-PHPdoc)
 	 * @see ResultPrinter::handleParameters()
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		// init process graph instance
@@ -102,7 +102,7 @@ class SRFProcess extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['graphname'] = [
@@ -695,7 +695,7 @@ class ProcessGraph {
 		$this->m_highlightNode = $name;
 	}
 
-	public function addError( $error ) {
+	public function addError( $error ): void {
 		$this->m_errors[] = $error;
 	}
 

--- a/formats/incoming/SRF_Incoming.php
+++ b/formats/incoming/SRF_Incoming.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 use SMW\RequestOptions;

--- a/formats/incoming/SRF_Incoming.php
+++ b/formats/incoming/SRF_Incoming.php
@@ -170,7 +170,7 @@ class SRFIncoming extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['sep'] = [

--- a/formats/jqplot/SRF_jqPlot.php
+++ b/formats/jqplot/SRF_jqPlot.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Linker\Linker;
 use SMW\Query\ResultPrinters\AggregatablePrinter;
 
 /**
@@ -18,7 +19,7 @@ abstract class SRFjqPlot extends AggregatablePrinter {
 	/**
 	 * @inheritDoc
 	 */
-	protected function getLinker( $firstcol = false ) {
+	protected function getLinker( $firstcol = false ): ?Linker {
 		// *** force null since labels are never clickable
 				return null;
 	}

--- a/formats/jqplot/SRF_jqPlotChart.php
+++ b/formats/jqplot/SRF_jqPlotChart.php
@@ -234,7 +234,7 @@ class SRFjqPlotChart extends SRFjqPlot {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = self::getCommonParams();
 
 		$params['charttype'] = [

--- a/formats/jqplot/SRF_jqPlotChart.php
+++ b/formats/jqplot/SRF_jqPlotChart.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\Html\Html;
+
 /**
  * A query printer for bar, line, pie and donut chart on aggregated values
  * using the jqPlot JavaScript library.

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -141,7 +141,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 	 *
 	 * @return array
 	 */
-	private function getFormatSettings( $data, $options ) {
+	private function getFormatSettings( $data, $options ): array {
 		// Init
 		$dataSet = [];
 		$options['mode'] = 'series';
@@ -373,7 +373,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = array_merge( parent::getParamDefinitions( $definitions ), SRFjqPlot::getCommonParams() );
 
 		$params['infotext'] = [

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -4,8 +4,9 @@ namespace SRF;
 
 use File;
 use FormatJson;
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
 use SMW\Query\ResultPrinters\ResultPrinter;
@@ -13,7 +14,6 @@ use SMWDataItem;
 use SMWDataValue;
 use SMWOutputs;
 use SRFUtils;
-use Title;
 
 /**
  * HTML5 Audio / Video media query printer

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -335,7 +335,7 @@ class MediaPlayer extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['class'] = [

--- a/formats/slideshow/SRF_SlideShow.php
+++ b/formats/slideshow/SRF_SlideShow.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\DataValues\PropertyValue;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/slideshow/SRF_SlideShow.php
+++ b/formats/slideshow/SRF_SlideShow.php
@@ -130,7 +130,7 @@ class SRFSlideShow extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['template'] = [

--- a/formats/slideshow/SRF_SlideShowApi.php
+++ b/formats/slideshow/SRF_SlideShowApi.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Title\Title;
 use ParamProcessor\ParamDefinition;
 use SMW\DataValueFactory;
 use SMW\Query\PrintRequest;

--- a/formats/sparkline/SRF_Sparkline.php
+++ b/formats/sparkline/SRF_Sparkline.php
@@ -91,7 +91,7 @@ class SRFSparkline extends AggregatablePrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['min'] = [

--- a/formats/sparkline/SRF_Sparkline.php
+++ b/formats/sparkline/SRF_Sparkline.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\ResultPrinters\AggregatablePrinter;
 
 /**

--- a/formats/spreadsheet/SpreadsheetPrinter.php
+++ b/formats/spreadsheet/SpreadsheetPrinter.php
@@ -3,6 +3,7 @@
 namespace SRF;
 
 use ImagePage;
+use MediaWiki\Title\Title;
 use PhpOffice\PhpSpreadsheet\Calculation\DateTime;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -17,7 +18,6 @@ use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
 use SMW\Query\ResultPrinters\FileExportPrinter;
 use SMWDataValue;
-use Title;
 
 /**
  * @author Kim Eik

--- a/formats/spreadsheet/SpreadsheetPrinter.php
+++ b/formats/spreadsheet/SpreadsheetPrinter.php
@@ -73,7 +73,7 @@ class SpreadsheetPrinter extends FileExportPrinter {
 	 *
 	 * @return string
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		return ( $this->params[ 'filename' ] ?: base_convert( uniqid(), 16, 36 ) ) . $this->fileFormat[ 'extension' ];
 	}
 
@@ -83,7 +83,7 @@ class SpreadsheetPrinter extends FileExportPrinter {
 	 * @param QueryResult $queryResult
 	 * @param array $params
 	 */
-	public function outputAsFile( QueryResult $queryResult, array $params ) {
+	public function outputAsFile( QueryResult $queryResult, array $params ): void {
 		if ( array_key_exists( 'fileformat', $params ) && array_key_exists( $params[ 'fileformat' ]->getValue(), $this->fileFormats ) ) {
 			$this->fileFormat = $this->fileFormats[ $params[ 'fileformat' ]->getValue() ];
 		} else {
@@ -98,7 +98,7 @@ class SpreadsheetPrinter extends FileExportPrinter {
 	 *
 	 * @return array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$definitions[ 'searchlabel' ]->setDefault( wfMessage( 'srf-spreadsheet-link' )->inContentLanguage()->text() );

--- a/formats/tagcloud/TagCloud.php
+++ b/formats/tagcloud/TagCloud.php
@@ -366,7 +366,7 @@ class TagCloud extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['template'] = [

--- a/formats/tagcloud/TagCloud.php
+++ b/formats/tagcloud/TagCloud.php
@@ -2,7 +2,8 @@
 
 namespace SRF;
 
-use Html;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
@@ -10,7 +11,6 @@ use SMW\Query\ResultPrinters\ResultPrinter;
 use SMWDataValue;
 use SMWOutputs;
 use SRFUtils;
-use Title;
 
 /**
  * Result printer that prints query results as a tag cloud

--- a/formats/time/SRF_Time.php
+++ b/formats/time/SRF_Time.php
@@ -85,7 +85,7 @@ class SRFTime extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['limit'] = [

--- a/formats/timeline/SRF_Timeline.php
+++ b/formats/timeline/SRF_Timeline.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/timeline/SRF_Timeline.php
+++ b/formats/timeline/SRF_Timeline.php
@@ -44,7 +44,7 @@ class SRFTimeline extends ResultPrinter {
 	 * @param array $params
 	 * @param $outputmode
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->mTemplate = trim( $params['template'] );
@@ -66,7 +66,7 @@ class SRFTimeline extends ResultPrinter {
 	}
 
 	protected function getResultText( QueryResult $res, $outputmode ) {
-		SMWOutputs::requireHeadItem( SMW_HEADER_STYLE );
+		SMWOutputs::requireStyle( 'ext.smw.styles' );
 		SMWOutputs::requireResource( 'ext.srf.timeline' );
 
 		$isEventline = 'eventline' == $this->mFormat;
@@ -330,9 +330,9 @@ class SRFTimeline extends ResultPrinter {
 				$curmeta .= Html::element(
 					'span',
 					[ 'class' => 'smwtlstart' ],
-					$object->getXMLSchemaDate()
+					$object->getISO8601Date( true )
 				);
-				$positions[$object->getHash()] = $object->getXMLSchemaDate();
+				$positions[$object->getHash()] = $object->getISO8601Date( true );
 				$hastime = true;
 			}
 
@@ -343,7 +343,7 @@ class SRFTimeline extends ResultPrinter {
 				$curmeta .= Html::element(
 					'span',
 					[ 'class' => 'smwtlend' ],
-					$object->getXMLSchemaDate( false )
+					$object->getISO8601Date( false )
 				);
 			}
 
@@ -379,7 +379,7 @@ class SRFTimeline extends ResultPrinter {
 				) == '_dat' ) && ( '' != $pr->getLabel(
 				) ) && ( $date_value != $this->m_tlstart ) && ( $date_value != $this->m_tlend ) ) {
 			$event = [
-				$object->getXMLSchemaDate(),
+				$object->getISO8601Date( true ),
 				$pr->getLabel(),
 				$object->getDataItem()->getSortKey(),
 			];
@@ -397,7 +397,7 @@ class SRFTimeline extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['timelinesize'] = [

--- a/formats/timeseries/SRF_Timeseries.php
+++ b/formats/timeseries/SRF_Timeseries.php
@@ -204,7 +204,7 @@ class SRFTimeseries extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['charttype'] = [

--- a/formats/timeseries/SRF_Timeseries.php
+++ b/formats/timeseries/SRF_Timeseries.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;
 

--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -9,12 +9,12 @@ namespace SRF\Formats\Tree;
  */
 
 use Exception;
-use Html;
+use MediaWiki\Html\Html;
+use MediaWiki\Title\Title;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ListResultPrinter;
-use Title;
 
 /**
  * Result printer that prints query results as a tree (nested html lists).

--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -10,6 +10,7 @@ namespace SRF\Formats\Tree;
 
 use Exception;
 use MediaWiki\Html\Html;
+use MediaWiki\Linker\Linker;
 use MediaWiki\Title\Title;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
@@ -37,7 +38,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * (non-PHPdoc)
 	 * @see \SMW\Query\ResultPrinters\ResultPrinter::getName()
 	 */
-	public function getName() {
+	public function getName(): string {
 		// Give grep a chance to find the usages:
 		// srf-printername-tree, srf-printername-ultree, srf-printername-oltree
 		return \Message::newFromKey( 'srf-printername-' . $this->mFormat )->text();
@@ -65,7 +66,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	/**
 	 * @see ResultPrinter::postProcessParameters()
 	 */
-	protected function postProcessParameters() {
+	protected function postProcessParameters(): void {
 		parent::postProcessParameters();
 
 		// Don't support pagination in trees
@@ -164,7 +165,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @return array of IParamDefinition|array
 	 * @throws Exception
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['parent'] = [
@@ -256,9 +257,9 @@ class TreeResultPrinter extends ListResultPrinter {
 	/**
 	 * Returns a linker object for making hyperlinks
 	 *
-	 * @return \Linker
+	 * @return Linker|null
 	 */
-	public function getLinker( $firstcol = false ) {
+	public function getLinker( $firstcol = false ): ?Linker {
 		return $this->mLinker;
 	}
 
@@ -268,7 +269,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 *
 	 * @param int $column Column number
 	 *
-	 * @return \Linker|null
+	 * @return Linker|null
 	 */
 	public function getLinkerForColumn( $column ) {
 		return parent::getLinker( $column === 0 );
@@ -358,7 +359,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @param string $msgkey
 	 * @param string | string[] $params
 	 */
-	protected function addError( $msgkey, $params = [] ) {
+	protected function addError( $msgkey, $params = [] ): void {
 		parent::addError(
 			\Message::newFromKey( $msgkey )
 				->params( $params )

--- a/formats/valuerank/SRF_ValueRank.php
+++ b/formats/valuerank/SRF_ValueRank.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/valuerank/SRF_ValueRank.php
+++ b/formats/valuerank/SRF_ValueRank.php
@@ -213,7 +213,7 @@ class SRFValueRank extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['includesubject'] = [

--- a/formats/widget/SRF_ListWidget.php
+++ b/formats/widget/SRF_ListWidget.php
@@ -105,7 +105,7 @@ class SRFListWidget extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['class'] = [

--- a/formats/widget/SRF_ListWidget.php
+++ b/formats/widget/SRF_ListWidget.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\ListResultPrinter\ListResultBuilder;
 use SMW\Query\ResultPrinters\ResultPrinter;

--- a/formats/widget/SRF_PageWidget.php
+++ b/formats/widget/SRF_PageWidget.php
@@ -33,7 +33,7 @@ class SRFPageWidget extends EmbeddedResultPrinter {
 	 *
 	 * @return string
 	 */
-	protected function getResultText( QueryResult $res, $outputMode ) {
+	protected function getResultText( QueryResult $res, $outputMode ): string {
 		// Initialize
 		static $statNr = 0;
 
@@ -83,7 +83,7 @@ class SRFPageWidget extends EmbeddedResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['embedformat'] = [

--- a/formats/widget/SRF_PageWidget.php
+++ b/formats/widget/SRF_PageWidget.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Html\Html;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinters\EmbeddedResultPrinter;
 

--- a/src/BibTex/BibTexFileExportPrinter.php
+++ b/src/BibTex/BibTexFileExportPrinter.php
@@ -81,7 +81,7 @@ class BibTexFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['filename'] = [

--- a/src/BibTex/BibTexFileExportPrinter.php
+++ b/src/BibTex/BibTexFileExportPrinter.php
@@ -59,7 +59,7 @@ class BibTexFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		if ( $this->params['filename'] !== '' ) {
 
 			if ( strpos( $this->params['filename'], '.bib' ) === false ) {

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Graph;
 
-use Html;
+use MediaWiki\Html\Html;
 
 /**
  *

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -2,7 +2,7 @@
 
 namespace SRF\Graph;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -98,7 +98,7 @@ class GraphPrinter extends ResultPrinter {
 	/**
 	 * @see ResultPrinter::handleParameters()
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->options = new GraphOptions( $params );
@@ -319,7 +319,7 @@ class GraphPrinter extends ResultPrinter {
 	 *
 	 * @return array of IParamDefinition|array
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['graphname'] = [

--- a/src/Outline/OutlineResultPrinter.php
+++ b/src/Outline/OutlineResultPrinter.php
@@ -30,7 +30,7 @@ class OutlineResultPrinter extends ResultPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function isDeferrable() {
+	public function isDeferrable(): bool {
 		return true;
 	}
 
@@ -41,7 +41,7 @@ class OutlineResultPrinter extends ResultPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['outlineproperties'] = [

--- a/src/iCalendar/iCalendarFileExportPrinter.php
+++ b/src/iCalendar/iCalendarFileExportPrinter.php
@@ -74,7 +74,7 @@ class iCalendarFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		if ( $this->title != '' ) {
 			return str_replace( ' ', '_', $this->title ) . '.ics';
 		}
@@ -100,7 +100,7 @@ class iCalendarFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['title'] = [
@@ -126,7 +126,7 @@ class iCalendarFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function handleParameters( array $params, $outputMode ) {
+	protected function handleParameters( array $params, $outputMode ): void {
 		parent::handleParameters( $params, $outputMode );
 
 		$this->title = trim( $params['title'] );

--- a/src/vCard/vCardFileExportPrinter.php
+++ b/src/vCard/vCardFileExportPrinter.php
@@ -55,7 +55,7 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getFileName( QueryResult $queryResult ) {
+	public function getFileName( QueryResult $queryResult ): string|false {
 		if ( $this->params['filename'] !== '' ) {
 
 			if ( strpos( $this->params['filename'], '.vcf' ) === false ) {
@@ -88,7 +88,7 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function getParamDefinitions( array $definitions ) {
+	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );
 
 		$params['filename'] = [

--- a/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
+++ b/tests/phpunit/Integration/I18nJsonFileIntegrityTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests\Integration;
 
-use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\Utils\UtilityFactory;
 
 /**
@@ -16,8 +15,6 @@ use SMW\Tests\Utils\UtilityFactory;
  */
 class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
 
-	use PHPUnitCompat;
-
 	/**
 	 * @covers I18nJsonFileIntegrity
 	 * @dataProvider i18nFileProvider
@@ -26,12 +23,10 @@ class I18nJsonFileIntegrityTest extends \PHPUnit\Framework\TestCase {
 		$jsonFileReader = UtilityFactory::getInstance()->newJsonFileReader( $file );
 
 		$this->assertIsInt(
-
 			$jsonFileReader->getModificationTime()
 		);
 
 		$this->assertIsArray(
-
 			$jsonFileReader->read()
 		);
 	}

--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -25,7 +25,7 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 	 * @see \SMW\Tests\JsonTestCaseScriptRunner::getTestCaseLocation
 	 * @return string
 	 */
-	protected function getTestCaseLocation() {
+	protected function getTestCaseLocation(): string {
 		return __DIR__ . '/TestCases';
 	}
 
@@ -33,7 +33,7 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 	 * @return string[]
 	 * @since 3.0
 	 */
-	protected function getPermittedSettings() {
+	protected function getPermittedSettings(): array {
 		$settings = parent::getPermittedSettings();
 		$settings[] = 'srfgMapProvider';
 		return $settings;
@@ -42,7 +42,7 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 	/**
 	 * @see JsonTestCaseScriptRunner::getDependencyDefinitions
 	 */
-	protected function getDependencyDefinitions() {
+	protected function getDependencyDefinitions(): array {
 		return [
 			'Mermaid' => [ $this, 'checkMermaidDependency' ]
 		];

--- a/tests/phpunit/Unit/Filtered/ResultItemTest.php
+++ b/tests/phpunit/Unit/Filtered/ResultItemTest.php
@@ -43,7 +43,7 @@ class ResultItemTest extends \PHPUnit\Framework\TestCase {
 		$resultArray->method( 'getNextDataValue' )->willReturnOnConsecutiveCalls( $dataValue );
 
 		$printRequest = $this->createStub( PrintRequest::class );
-		$printRequest->method( 'getHash' )->willReturn( null );
+		$printRequest->method( 'getHash' )->willReturn( '' );
 		$resultArray->method( 'getPrintRequest' )->willReturn( $printRequest );
 
 		$queryPrinter = new Filtered( null );

--- a/tests/phpunit/Unit/Formats/GalleryTest.php
+++ b/tests/phpunit/Unit/Formats/GalleryTest.php
@@ -3,7 +3,6 @@
 namespace SRF\Tests\Unit\Formats;
 
 use MediaWiki\Title\Title;
-use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRF\Gallery;
 
@@ -24,8 +23,6 @@ use SRF\Gallery;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class GalleryTest extends QueryPrinterRegistryTestCase {
-
-	use PHPUnitCompat;
 
 	private $queryResult;
 	private $title;
@@ -132,7 +129,7 @@ class GalleryTest extends QueryPrinterRegistryTestCase {
 			$outro
 		];
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'',
 			$instance->getResult( $this->queryResult, $parameters, SMW_OUTPUT_HTML )
 		);

--- a/tests/phpunit/Unit/Formats/GalleryTest.php
+++ b/tests/phpunit/Unit/Formats/GalleryTest.php
@@ -2,6 +2,7 @@
 
 namespace SRF\Tests\Unit\Formats;
 
+use MediaWiki\Title\Title;
 use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRF\Gallery;
@@ -36,7 +37,7 @@ class GalleryTest extends QueryPrinterRegistryTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->title = $this->getMockBuilder( '\Title' )
+		$this->title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Test;
 
-use ExtensionRegistry;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use Parser;

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -3,6 +3,7 @@
 namespace SRF\Test;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Title\Title;
 use Parser;
 use SMW\Tests\QueryPrinterRegistryTestCase;
@@ -83,7 +84,7 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 
 		$testObject = new TreeResultPrinter( 'tree' );
 
-		if ( version_compare( SMW_VERSION, '7.0.0', '>=' ) ) {
+		if ( ExtensionRegistry::getInstance()->isLoaded( 'SemanticMediaWiki', '>=7.0.0' ) ) {
 			$this->assertStringContainsString(
 				'',
 				$testObject->getResult( $queryResult, $params, SMW_OUTPUT_HTML ),

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -79,16 +79,12 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 		/** @var \PHPUnit_Framework_MockObject_MockObject $queryResult */
 		$queryResult = $mockBuilder->newObject( 'QueryResult', [ 'getCount' => 1 ] );
 
-		$queryResult->expects( $this->once() )
-			->method( 'addErrors' )
-			->willReturn( null );
-
 		$params = SMWQueryProcessor::getProcessedParams( [ 'format' => 'tree' ], [] );
 
 		$testObject = new TreeResultPrinter( 'tree' );
 
-		$this->assertSame(
-			null,
+		$this->assertStringContainsString(
+			'',
 			$testObject->getResult( $queryResult, $params, SMW_OUTPUT_HTML ),
 			'Result should be empty.'
 		);

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -83,11 +83,19 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 
 		$testObject = new TreeResultPrinter( 'tree' );
 
-		$this->assertStringContainsString(
-			'',
-			$testObject->getResult( $queryResult, $params, SMW_OUTPUT_HTML ),
-			'Result should be empty.'
-		);
+		if ( version_compare( SMW_VERSION, '7.0.0', '>=' ) ) {
+			$this->assertStringContainsString(
+				'',
+				$testObject->getResult( $queryResult, $params, SMW_OUTPUT_HTML ),
+				'Result should be empty.'
+			);
+		} else {
+			$this->assertSame(
+				null,
+				$testObject->getResult( $queryResult, $params, SMW_OUTPUT_HTML ),
+				'Result should be empty.'
+			);
+		}
 
 		// Restore GLOBAL state to ensure that preceding tests do not use a
 		// mocked instance

--- a/tests/phpunit/Unit/Formats/TreeTest.php
+++ b/tests/phpunit/Unit/Formats/TreeTest.php
@@ -4,6 +4,7 @@ namespace SRF\Test;
 
 use ExtensionRegistry;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use Parser;
 use SMW\Tests\QueryPrinterRegistryTestCase;
 use SMW\Tests\Utils\Mock\CoreMockObjectRepository;
@@ -120,7 +121,7 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 			->method( 'parse' )
 			->willReturn( $parserOutput );
 
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -135,18 +136,13 @@ class TreeTest extends QueryPrinterRegistryTestCase {
 	 * @param Parser $parser
 	 */
 	protected function replaceParser( Parser $parser ) {
-		// Direct access to the wgParser global was removed in SMW 4.0.0.
-		if ( ExtensionRegistry::getInstance()->isLoaded( 'SemanticMediaWiki', '<4.0.0' ) ) {
-			$GLOBALS['wgParser'] = $parser;
-		} else {
-			MediaWikiServices::getInstance()->disableService( 'Parser' );
-			MediaWikiServices::getInstance()->redefineService(
-				'Parser',
-				static function () use ( $parser ) {
-					return $parser;
-				}
-			);
-		}
+		MediaWikiServices::getInstance()->disableService( 'Parser' );
+		MediaWikiServices::getInstance()->redefineService(
+			'Parser',
+			static function () use ( $parser ) {
+				return $parser;
+			}
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/Formats/ValueRankTest.php
+++ b/tests/phpunit/Unit/Formats/ValueRankTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests\Unit\Formats;
 
-use SMW\Tests\PHPUnitCompat;
 use SMW\Tests\QueryPrinterRegistryTestCase;
 use SRFValueRank;
 
@@ -23,8 +22,6 @@ use SRFValueRank;
  * @author Sebastian Schmid < sebastian.schmid@geinn.it >
  */
 class ValueRankTest extends QueryPrinterRegistryTestCase {
-
-	use PHPUnitCompat;
 
 	/**
 	 * @see QueryPrinterRegistryTestCase::getFormats

--- a/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/ListTreeBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests\Outline;
 
-use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\ListTreeBuilder;
 use SRF\Outline\OutlineTree;
 
@@ -16,8 +15,6 @@ use SRF\Outline\OutlineTree;
  * @author mwjames
  */
 class ListTreeBuilderTest extends \PHPUnit\Framework\TestCase {
-
-	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineResultPrinterTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests\Outline;
 
-use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\OutlineResultPrinter;
 
 /**
@@ -15,8 +14,6 @@ use SRF\Outline\OutlineResultPrinter;
  * @author mwjames
  */
 class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
-
-	use PHPUnitCompat;
 
 	private $queryResult;
 
@@ -114,7 +111,7 @@ class OutlineResultPrinterTest extends \PHPUnit\Framework\TestCase {
 			$outrotemplate
 		];
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			"<ul>\n</ul>\n",
 			$instance->getResult( $this->queryResult, $parameters, SMW_OUTPUT_HTML )
 		);

--- a/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
+++ b/tests/phpunit/Unit/Outline/TemplateBuilderTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests\Outline;
 
-use SMW\Tests\PHPUnitCompat;
 use SRF\Outline\OutlineTree;
 use SRF\Outline\TemplateBuilder;
 
@@ -16,8 +15,6 @@ use SRF\Outline\TemplateBuilder;
  * @author mwjames
  */
 class TemplateBuilderTest extends \PHPUnit\Framework\TestCase {
-
-	use PHPUnitCompat;
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
@@ -38,7 +35,6 @@ class TemplateBuilderTest extends \PHPUnit\Framework\TestCase {
 		$instance = new TemplateBuilder( $params );
 
 		$this->assertIsString(
-
 			$instance->build( new OutlineTree() )
 		);
 	}

--- a/tests/phpunit/Unit/ResourceFormatterTest.php
+++ b/tests/phpunit/Unit/ResourceFormatterTest.php
@@ -2,7 +2,6 @@
 
 namespace SRF\Tests;
 
-use SMW\Tests\PHPUnitCompat;
 use SRF\ResourceFormatter;
 
 /**
@@ -16,10 +15,8 @@ use SRF\ResourceFormatter;
  */
 class ResourceFormatterTest extends \PHPUnit\Framework\TestCase {
 
-	use PHPUnitCompat;
-
 	public function testSession() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'smw-',
 			ResourceFormatter::session()
 		);
@@ -27,7 +24,6 @@ class ResourceFormatterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testPlaceholder() {
 		$this->assertIsString(
-
 			ResourceFormatter::placeholder()
 		);
 	}


### PR DESCRIPTION
* Adds support for MW 1.44 and MW 1.45.
* Bumps the minimum MW version to 1.43.
* Adds support for SMW 7.0

SMW 7.0 fixes running tests under MW 1.44-1.45 and thus we have to use it for those releases.