### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
     "name": "SemanticResultFormats",
-	"version": "5.2.0",
+	"version": "6.0.0",
 	"author": [
 		"James Hong Kong",
 		"Stephan Gambke",


### PR DESCRIPTION
With the droppage of MW 1.39 and the requirement of at least MW 1.43+ now. Let's bump the version to 6.0.0.