### PR TITLE
fix(qa): resolve trivial Phan issues (Group A, #1008)

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -36,7 +36,6 @@ return [
     // PhanUndeclaredFunction : 7 occurrences
     // PhanCompatibleUnionType : 6 occurrences
     // PhanPluginDuplicateConditionalTernaryDuplication : 5 occurrences
-    // PhanPluginSimplifyExpressionBool : 5 occurrences
     // PhanTypeMismatchArgumentInternal : 5 occurrences
     // PhanTypeMismatchReturnProbablyReal : 5 occurrences
     // PhanPluginDuplicateExpressionAssignmentOperation : 4 occurrences
@@ -53,19 +52,16 @@ return [
     // PhanTypeMismatchProperty : 2 occurrences
     // PhanUndeclaredClassStaticProperty : 2 occurrences
     // SecurityCheck-DoubleEscaped : 2 occurrences
-    // MediaWikiNoBaseException : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanParamSpecial1 : 1 occurrence
     // PhanParamTooMany : 1 occurrence
-    // PhanPluginDuplicateAdjacentStatement : 1 occurrence
-    // PhanPluginDuplicateExpressionAssignment : 1 occurrence
+    // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanSuspiciousBinaryAddLists : 1 occurrence
     // PhanSuspiciousWeakTypeComparison : 1 occurrence
     // PhanTypeComparisonFromArray : 1 occurrence
     // PhanTypeInvalidLeftOperandOfAdd : 1 occurrence
     // PhanTypeMismatchDimAssignment : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
-    // PhanTypeMissingReturn : 1 occurrence
     // PhanUndeclaredClassCatch : 1 occurrence
     // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
@@ -112,8 +108,8 @@ return [
         'formats/incoming/SRF_Incoming.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/jqplot/SRF_jqPlot.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredExtendedClass'],
         'formats/jqplot/SRF_jqPlotChart.php' => ['PhanPluginDuplicateConditionalTernaryDuplication', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredStaticMethod', 'PhanUndeclaredVariableDim'],
-        'formats/jqplot/SRF_jqPlotSeries.php' => ['PhanPluginDuplicateConditionalTernaryDuplication', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredVariableDim'],
-        'formats/math/SRF_Math.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanSuspiciousBinaryAddLists', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
+        'formats/jqplot/SRF_jqPlotSeries.php' => ['PhanPluginDuplicateConditionalTernaryDuplication', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredVariableDim'],
+        'formats/math/SRF_Math.php' => ['PhanRedundantCondition', 'PhanSuspiciousBinaryAddLists', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/media/MediaPlayer.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/slideshow/SRF_SlideShow.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/slideshow/SRF_SlideShowApi.php' => ['PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
@@ -125,7 +121,7 @@ return [
         'formats/timeseries/SRF_Timeseries.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredVariableDim'],
         'formats/tree/TreeNode.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
         'formats/tree/TreeNodeVisitor.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredInterface', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
-        'formats/tree/TreeResultPrinter.php' => ['MediaWikiNoBaseException', 'MediaWikiNoEmptyIfDefined', 'PhanTypeMismatchArgument', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
+        'formats/tree/TreeResultPrinter.php' => ['MediaWikiNoEmptyIfDefined', 'PhanTypeMismatchArgument', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
         'formats/valuerank/SRF_ValueRank.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/widget/SRF_ListWidget.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'formats/widget/SRF_PageWidget.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
@@ -136,10 +132,10 @@ return [
         'src/Graph/GraphPrinter.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
         'src/Outline/ListTreeBuilder.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredConstant', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'src/Outline/OutlineResultPrinter.php' => ['PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
-        'src/Outline/TemplateBuilder.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanUndeclaredClassConstant', 'PhanUndeclaredConstant', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'src/Outline/TemplateBuilder.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredConstant', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'src/ResourceFormatter.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'src/iCalendar/DateParser.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
-        'src/iCalendar/IcalTimezoneFormatter.php' => ['PhanPluginDuplicateExpressionAssignment', 'PhanTypeComparisonFromArray'],
+        'src/iCalendar/IcalTimezoneFormatter.php' => ['PhanTypeComparisonFromArray'],
         'src/iCalendar/iCalendarFileExportPrinter.php' => ['PhanCompatibleUnionType', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
         'src/vCard/vCard.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/vCard/vCardFileExportPrinter.php' => ['PhanCompatibleUnionType', 'PhanTypeMismatchArgument', 'PhanUndeclaredClass', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredVariableDim'],

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -262,7 +262,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 	 * @since 1.8
 	 *
 	 *
-	 * @return string
+	 * @return void
 	 */
 	protected function addResources() {
 		// RL module

--- a/formats/math/SRF_Math.php
+++ b/formats/math/SRF_Math.php
@@ -107,7 +107,7 @@ class MathFormats {
 		// get position
 		$Q1_position = ( ( count( $numbers ) - 1 ) * 0.25 );
 		// check if position is between two numbers
-		if ( is_float( $Q1_position ) == true ) {
+		if ( is_float( $Q1_position ) ) {
 			$Q1_position_y = floor( $Q1_position );
 			$Q1_position_x = ceil( $Q1_position );
 			// result
@@ -123,7 +123,7 @@ class MathFormats {
 		// get position
 		$Q3_position = ( ( count( $numbers ) - 1 ) * 0.75 );
 		// check if position is between two numbers
-		if ( is_float( $Q3_position ) == true ) {
+		if ( is_float( $Q3_position ) ) {
 			$Q3_position_y = floor( $Q3_position );
 			$Q3_position_x = ceil( $Q3_position );
 			// result
@@ -139,7 +139,7 @@ class MathFormats {
 		// get position
 		$Q1_position = ( ( count( $numbers ) + 1 ) * 0.25 );
 		// check if position is between two numbers
-		if ( is_float( $Q1_position ) == true ) {
+		if ( is_float( $Q1_position ) ) {
 			$Q1_position_y = floor( $Q1_position ) - 1;
 			$Q1_position_x = ceil( $Q1_position ) - 1;
 			// result
@@ -155,7 +155,7 @@ class MathFormats {
 		// get position
 		$Q3_position = ( ( count( $numbers ) + 1 ) * 0.75 );
 		// check if position is between two numbers
-		if ( is_float( $Q3_position ) == true ) {
+		if ( is_float( $Q3_position ) ) {
 			$Q3_position_y = floor( $Q3_position ) - 1;
 			$Q3_position_x = ceil( $Q3_position ) - 1;
 			// result

--- a/formats/tree/TreeResultPrinter.php
+++ b/formats/tree/TreeResultPrinter.php
@@ -12,6 +12,7 @@ use Exception;
 use MediaWiki\Html\Html;
 use MediaWiki\Linker\Linker;
 use MediaWiki\Title\Title;
+use MWException;
 use SMW\DIProperty;
 use SMW\DIWikiPage;
 use SMW\Query\QueryResult;
@@ -46,11 +47,11 @@ class TreeResultPrinter extends ListResultPrinter {
 
 	/**
 	 * @return QueryResult
-	 * @throws Exception
+	 * @throws MWException
 	 */
 	public function getQueryResult() {
 		if ( $this->queryResult === null ) {
-			throw new Exception( __METHOD__ . ' called outside of ' . __CLASS__ . '::getResultText().' );
+			throw new MWException( __METHOD__ . ' called outside of ' . __CLASS__ . '::getResultText().' );
 		}
 
 		return $this->queryResult;
@@ -163,7 +164,7 @@ class TreeResultPrinter extends ListResultPrinter {
 	 * @param $definitions array of IParamDefinition
 	 *
 	 * @return array of IParamDefinition|array
-	 * @throws Exception
+	 * @throws MWException
 	 */
 	public function getParamDefinitions( array $definitions ): array {
 		$params = parent::getParamDefinitions( $definitions );

--- a/src/Outline/TemplateBuilder.php
+++ b/src/Outline/TemplateBuilder.php
@@ -73,8 +73,7 @@ class TemplateBuilder {
 			$this->template .= $this->close();
 			$this->template .= "<div class='" . $this->params['template'] . "-items'>";
 			$this->tree( $node, $level + 1 );
-			$this->template .= "</div>";
-			$this->template .= "</div>";
+			$this->template .= "</div></div>";
 		}
 	}
 

--- a/src/iCalendar/IcalTimezoneFormatter.php
+++ b/src/iCalendar/IcalTimezoneFormatter.php
@@ -46,7 +46,7 @@ class IcalTimezoneFormatter {
 	 */
 	public function setLocalTimezones( $localTimezones ) {
 		if ( is_array( $localTimezones ) ) {
-			$localTimezones = $localTimezones;
+			// already an array, nothing to do
 		} elseif ( strpos( $localTimezones, ',' ) !== false ) {
 			$localTimezones = explode( ',', $localTimezones );
 		} elseif ( $localTimezones !== '' ) {
@@ -123,7 +123,7 @@ class IcalTimezoneFormatter {
 	public function getTransitions() {
 		$result = '';
 
-		if ( $this->transitions === null || $this->transitions === [] ) {
+		if ( $this->transitions === [] ) {
 			return $result;
 		}
 


### PR DESCRIPTION
Closes #1008

Resolves a set of trivial, zero-behavior-change Phan issues that were suppressed in the baseline introduced by #1007.

## Changes

- `src/iCalendar/IcalTimezoneFormatter.php` — remove no-op self-assignment (`PhanPluginDuplicateExpressionAssignment`); remove impossible `=== null` check on typed array (`PhanTypeComparisonFromArray`)
- `src/Outline/TemplateBuilder.php` — merge two adjacent identical `</div>` statements (`PhanPluginDuplicateAdjacentStatement`)
- `formats/math/SRF_Math.php` — simplify `is_float(...) == true` → `is_float(...)` at 4 locations (`PhanPluginSimplifyExpressionBool`)
- `formats/jqplot/SRF_jqPlotSeries.php` — fix `@return string` docblock on void method `addResources()` (`PhanTypeMissingReturn`)
- `formats/tree/TreeResultPrinter.php` — replace bare `Exception` throw with `MWException` (`MediaWikiNoBaseException`); `catch` retains `Exception` to also cover `Cdb\Exception` from `TreeNode`
- `.phan/baseline.php` — updated accordingly

## Testing

- All fixes verified against the local CI gate (`composer test`): phpcs, phplint, MinusX, PHPUnit all green
- Only pre-existing risky tests (6x, no assertions) remain — unrelated to these changes