### PR TITLE
fix(qa): fix PhanPluginDuplicateExpressionAssignmentOperation and PhanPluginSimplifyExpressionBool in DataTables

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -38,11 +38,11 @@ return [
     // PhanPluginDuplicateConditionalTernaryDuplication : 5 occurrences
     // PhanTypeMismatchArgumentInternal : 5 occurrences
     // PhanTypeMismatchReturnProbablyReal : 5 occurrences
-    // PhanPluginDuplicateExpressionAssignmentOperation : 4 occurrences
-    // PhanTypeInvalidLeftOperandOfNumericOp : 4 occurrences
     // PhanTypeMismatchForeach : 4 occurrences
     // PhanTypeSuspiciousStringExpression : 4 occurrences
     // PhanImpossibleConditionInLoop : 3 occurrences
+    // PhanPluginDuplicateExpressionAssignmentOperation : 3 occurrences
+    // PhanTypeInvalidLeftOperandOfNumericOp : 3 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
     // PhanPluginUseReturnValueInternalKnown : 2 occurrences
@@ -55,7 +55,6 @@ return [
     // PhanParamSignatureMismatch : 1 occurrence
     // PhanParamSpecial1 : 1 occurrence
     // PhanParamTooMany : 1 occurrence
-    // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanSuspiciousBinaryAddLists : 1 occurrence
     // PhanSuspiciousWeakTypeComparison : 1 occurrence
     // PhanTypeComparisonFromArray : 1 occurrence
@@ -87,7 +86,7 @@ return [
         'formats/d3/SRF_D3Chart.php' => ['PhanPluginDuplicateConditionalTernaryDuplication', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty', 'PhanUndeclaredVariableDim'],
         'formats/dataframe/DataframePrinter.php' => ['PhanCompatibleUnionType', 'PhanParamSpecial1', 'PhanPossiblyUndeclaredVariable', 'PhanUndeclaredClass', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredVariableDim'],
         'formats/datatables/Api.php' => ['PhanParamTooMany', 'PhanTypeArraySuspiciousNullable', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredMethod', 'PhanUndeclaredVariableDim'],
-        'formats/datatables/DataTables.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClass', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredStaticProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredVariableDim'],
+        'formats/datatables/DataTables.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClass', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredStaticProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredVariableDim'],
         'formats/datatables/Hooks.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod'],
         'formats/datatables/QuerySegmentListProcessor.php' => ['PhanPluginDuplicateConditionalTernaryDuplication', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'formats/datatables/SearchPanes.php' => ['MediaWikiNoEmptyIfDefined', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassStaticProperty', 'PhanUndeclaredConstant', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],

--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -747,7 +747,7 @@ class DataTables extends ResultPrinter {
 		$tableAttrs = [
 			'class' => 'srf-datatable wikitable display' . ( $this->params['class'] ? ' ' . $this->params['class'] : '' ),
 			'data-collation' => !empty( $GLOBALS['smwgEntityCollation'] ) ? $GLOBALS['smwgEntityCollation'] : $GLOBALS['wgCategoryCollation'],
-			'data-nocase' => ( $GLOBALS['smwgFieldTypeFeatures'] === SMW_FIELDT_CHAR_NOCASE ? true : false ),
+			'data-nocase' => $GLOBALS['smwgFieldTypeFeatures'] === SMW_FIELDT_CHAR_NOCASE,
 			'data-column-sort' => json_encode( [
 				'list'  => $headerList,
 				'sort'  => $this->params['sort'],
@@ -863,7 +863,7 @@ class DataTables extends ResultPrinter {
 						break;
 
 					case "number":
-						$value = $value * 1;
+						$value = (float)$value;
 						break;
 
 					// ...

--- a/tests/phpunit/Integration/JSONScript/TestCases/datatables-02.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/datatables-02.json
@@ -1,0 +1,75 @@
+{
+	"description": "Test `format=datatables` with printout parameter options (number/boolean casting)",
+	"setup": [
+		{
+			"page": "Has temperature",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Example/Datatables2/1",
+			"contents": "[[Has temperature::20]] [[Category:Datatables2]]"
+		},
+		{
+			"page": "Example/Datatables2/2",
+			"contents": "[[Has temperature::25]] [[Category:Datatables2]]"
+		},
+		{
+			"page": "Test/Datatables2/Q.1",
+			"contents": "{{#ask: [[Category:Datatables2]] |?Has temperature |format=datatables }}"
+		},
+		{
+			"page": "Test/Datatables2/Q.2",
+			"contents": "{{#ask: [[Category:Datatables2]] |?Has temperature |+ datatables-columns.searchPanes.threshold = 0.3 |format=datatables }}"
+		},
+		{
+			"page": "Test/Datatables2/Q.3",
+			"contents": "{{#ask: [[Category:Datatables2]] |?Has temperature |+ datatables-columns.orderable = true |format=datatables }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 basic datatables output renders container and table",
+			"subject": "Test/Datatables2/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"class=\"datatables-container\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 datatables with searchPanes.threshold number parameter renders without error",
+			"subject": "Test/Datatables2/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"class=\"datatables-container\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 datatables with orderable boolean parameter renders without error",
+			"subject": "Test/Datatables2/Q.3",
+			"assert-output": {
+				"to-contain": [
+					"class=\"datatables-container\""
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
Closes #1014

## Summary

Two Phan plugin issues in `formats/datatables/DataTables.php`:

### PhanPluginSimplifyExpressionBool
`$x === $y ? true : false` → simplified to the direct boolean expression `$x === $y`

### PhanPluginDuplicateExpressionAssignmentOperation
`$value = $value * 1` → `$value = (float)$value`

The `* 1` pattern was intended as a string-to-number cast for the `searchPanes.threshold` parameter (a float value). Using an explicit cast is clearer and avoids the Phan warning. As a side effect, `PhanTypeInvalidLeftOperandOfNumericOp` count also drops by 1.

## Baseline changes

- `PhanPluginSimplifyExpressionBool` suppression removed
- `PhanPluginDuplicateExpressionAssignmentOperation` occurrences: 4 → 3
- `PhanTypeInvalidLeftOperandOfNumericOp` occurrences: 4 → 3

## Tests added

New JSONScript integration test `datatables-02.json` covering:
- Basic datatables output
- `searchPanes.threshold` number parameter (float cast path)
- `orderable` boolean parameter