### PR TITLE
fix(phpcs): remove AssertEmpty and SpaceBeforeSingleLineComment excludes

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -17,7 +17,6 @@
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />
-		<exclude name="MediaWiki.PHPUnit.AssertEmpty.AssertEmptyUsed" />
 		<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
 		<exclude name="Generic.ControlStructures.DisallowYodaConditions.Found" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.WrongStyle" />
@@ -25,7 +24,6 @@
 		<exclude name="MediaWiki.NamingConventions.ValidGlobalName.allowedPrefix" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />
 		<exclude name="MediaWiki.Usage.DeprecatedGlobalVariables.Deprecated$wgContLang" />
-		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
 		<exclude name="MediaWiki.Usage.DeprecatedGlobalVariables.Deprecated$wgTitle" />
 	</rule>
 	<rule ref="MediaWiki.NamingConventions.ValidGlobalName">

--- a/formats/array/SRF_Array.php
+++ b/formats/array/SRF_Array.php
@@ -300,7 +300,8 @@ class SRFArray extends ResultPrinter {
 				// cache can't be initialized, probably function-reference in user config
 				// but format is not used in inline context, use fallback in this case:
 				global $wgSrfgArraySepTextualFallbacks;
-				$cache = $wgSrfgArraySepTextualFallbacks[$dfltCacheKey] ?? ''; // Default to empty string
+				// Default to empty string
+				$cache = $wgSrfgArraySepTextualFallbacks[$dfltCacheKey] ?? '';
 			}
 		}
 		return $cache;

--- a/formats/datatables/QuerySegmentListProcessor.php
+++ b/formats/datatables/QuerySegmentListProcessor.php
@@ -117,7 +117,7 @@ class QuerySegmentListProcessor {
 
 	private function segment( QuerySegment &$query ) {
 		switch ( $query->type ) {
-			case QuerySegment::Q_TABLE: // .
+			case QuerySegment::Q_TABLE:
 				$this->table( $query );
 				break;
 			case QuerySegment::Q_CONJUNCTION:
@@ -127,11 +127,13 @@ class QuerySegmentListProcessor {
 				$this->disjunction( $query );
 				break;
 			case QuerySegment::Q_PROP_HIERARCHY:
-			case QuerySegment::Q_CLASS_HIERARCHY: // make a saturated hierarchy
+			case QuerySegment::Q_CLASS_HIERARCHY:
+				// make a saturated hierarchy
 				$this->hierarchy( $query );
 				break;
 			case QuerySegment::Q_VALUE:
-				break; // nothing to do
+				// nothing to do
+				break;
 		}
 	}
 
@@ -144,7 +146,8 @@ class QuerySegmentListProcessor {
 			$this->segment( $subQuery );
 			$alias = $subQuery->alias;
 
-			if ( $subQuery->joinTable !== '' ) { // Join with jointable.joinfield
+			// Join with jointable.joinfield
+			if ( $subQuery->joinTable !== '' ) {
 				$op = $subQuery->not ? '!' : '';
 
 				$joinType = $subQuery->joinType ? $subQuery->joinType : 'INNER';
@@ -177,7 +180,8 @@ class QuerySegmentListProcessor {
 					$query->where .= ( ( $query->where === '' ) ? '' : ' AND ' ) . '(' . $subQuery->joinfield . ' IS NULL)';
 				}
 
-			} elseif ( $subQuery->joinfield !== '' ) { // Require joinfield as "value" via WHERE.
+			// Require joinfield as "value" via WHERE.
+			} elseif ( $subQuery->joinfield !== '' ) {
 				$condition = '';
 
 				if ( $subQuery->null === true ) {
@@ -197,8 +201,10 @@ class QuerySegmentListProcessor {
 				$query->from .= $subQuery->from;
 				$query->fromTables = array_merge( (array)$query->fromTables, (array)$subQuery->fromTables );
 				$query->joinConditions = array_merge( (array)$query->joinConditions, (array)$subQuery->joinConditions );
-			} else { // interpret empty joinfields as impossible condition (empty result)
-				$query->joinfield = ''; // make whole query false
+			// interpret empty joinfields as impossible condition (empty result)
+			} else {
+				// make whole query false
+				$query->joinfield = '';
 				$query->joinTable = '';
 				$query->where = '';
 				$query->from = '';
@@ -282,7 +288,8 @@ class QuerySegmentListProcessor {
 				}
 
 				$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' . $this->connection->tableName( $query->alias ) . " (id) VALUES $values";
-			} // else: // interpret empty joinfields as impossible condition (empty result), ignore
+			}
+			// else: interpret empty joinfields as impossible condition (empty result), ignore
 
 			if ( $sql ) {
 				$this->executedQueries[$query->alias][] = $sql;
@@ -303,7 +310,8 @@ class QuerySegmentListProcessor {
 
 		$query->joinTable = $query->alias;
 		$query->joinfield = "$query->alias.id";
-		$query->sortfields = []; // Make sure we got no sortfields.
+		// Make sure we got no sortfields.
+		$query->sortfields = [];
 
 		// TODO: currently this eliminates sortkeys, possibly keep them (needs
 		// different temp table format though, maybe not such a good thing to do)
@@ -334,7 +342,8 @@ class QuerySegmentListProcessor {
 			$depth = $query->depth;
 		}
 
-		if ( $depth <= 0 ) { // treat as value, no recursion
+		// treat as value, no recursion
+		if ( $depth <= 0 ) {
 			$query->type = QuerySegment::Q_VALUE;
 			return;
 		}
@@ -350,7 +359,8 @@ class QuerySegmentListProcessor {
 		// Try to save time (SELECT is cheaper than creating/dropping 3 temp tables):
 		$res = $this->connection->query( "SELECT s_id FROM $smwtable WHERE $valuecond LIMIT 1" );
 
-		if ( !$res->fetchObject() ) { // no subobjects, we are done!
+		// no subobjects, we are done!
+		if ( !$res->fetchObject() ) {
 			$res->free();
 			$query->type = QuerySegment::Q_VALUE;
 			return;

--- a/formats/graphviz/SRF_Process.php
+++ b/formats/graphviz/SRF_Process.php
@@ -210,7 +210,8 @@ class SRFProcess extends ResultPrinter {
 			return '';
 		}
 
-		global $wgContLang; // content language object
+		// content language object
+		global $wgContLang;
 
 		//
 		//	GraphViz settings

--- a/tests/phpunit/Unit/Outline/OutlineTreeTest.php
+++ b/tests/phpunit/Unit/Outline/OutlineTreeTest.php
@@ -25,11 +25,13 @@ class OutlineTreeTest extends \PHPUnit\Framework\TestCase {
 	public function testPropertyAccess() {
 		$instance = new OutlineTree();
 
-		$this->assertEmpty(
+		$this->assertSame(
+			[],
 			$instance->tree
 		);
 
-		$this->assertEmpty(
+		$this->assertSame(
+			[],
 			$instance->items
 		);
 


### PR DESCRIPTION
Closes #1016

## Changes

- Replace `assertEmpty()` with `assertSame([], ...)` in `OutlineTreeTest`
- Move inline comments to their own line in `SRF_Array`, `QuerySegmentListProcessor`, `SRF_Process`
- Remove `MediaWiki.PHPUnit.AssertEmpty.AssertEmptyUsed` exclude from `.phpcs.xml`
- Remove `MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment` exclude from `.phpcs.xml`

Part of the ongoing effort to reduce the PHPCS exclude list.