### PR TITLE
test(formats): add JSONScript integration tests for array, calendar, spreadsheet, jqplot, googlecharts, dataframe, prolog + CI bump (#1018)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,11 @@ jobs:
     strategy:
       matrix:
         include:
+          # SMW 6.0.1 has a bug where #ask returns empty results in the prepareContentForEdit
+          # context used by JSONScript parser-type tests. Upgraded to dev-master as workaround;
+          # pin to 7.x once released. See: https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1020
           - mediawiki_version: '1.43'
-            smw_version: 6.0.1
+            smw_version: dev-master
             php_version: 8.1
             mm_version: 6.0.1
             database_type: mysql
@@ -26,7 +29,7 @@ jobs:
             coverage: false
             experimental: false
           - mediawiki_version: '1.43'
-            smw_version: 6.0.1
+            smw_version: dev-master
             pf_version: 5.9
             sfs_version: 4.0.0-beta
             php_version: 8.3

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ DB_TYPE?=mysql
 DB_IMAGE?="mariadb:11.2"
 
 # extensions
-SMW_VERSION ?= 6.0.1
+# SMW 6.0.1 has a bug where #ask returns empty results in the prepareContentForEdit context
+# used by JSONScript parser-type tests. Fixed in dev-master; pin to 7.x once released.
+SMW_VERSION ?= dev-master
 PF_VERSION ?= 6.0.5
 SFS_VERSION ?= 4.0.0-beta
 MM_VERSION ?= 6.0.2
@@ -26,12 +28,31 @@ MM_VERSION ?= 6.0.2
 # Enables "composer update" inside of extension
 COMPOSER_EXT?=true
 
+# OS packages and PHP extensions required for optional formats:
+# - libzip-dev + zip: prerequisite for phpoffice/phpspreadsheet (format=spreadsheet)
+# - gd: required by phpoffice/phpspreadsheet at install time
+OS_PACKAGES?=libzip-dev libpng-dev
+PHP_EXTENSIONS?=zip gd
+
 # nodejs
 # Enables node.js related tests and "npm install"
 # NODE_JS?=true
 
 # check for build dir and git submodule init if it does not exist
 include build/Makefile
+
+# Chain install-spreadsheet into make install so phpspreadsheet is always available
+# after a full install. The prerequisite order ensures it runs after .install completes.
+install: install-spreadsheet
+
+# Install phpoffice/phpspreadsheet for format=spreadsheet tests.
+# phpspreadsheet is listed as "suggest" in SRF's composer.json (not "require"), so it
+# cannot be pulled in via the composer-merge-plugin; an explicit install step is needed.
+# composer-require.sh only updates composer.local.json; the follow-up "composer update"
+# actually downloads and installs the package into the running container.
+.PHONY: install-spreadsheet
+install-spreadsheet: .init
+	$(compose-exec-wiki) bash -c "composer-require.sh phpoffice/phpspreadsheet 1.22.0 && composer update phpoffice/phpspreadsheet --with-all-dependencies"
 
 .PHONY: composer-phan
 composer-phan: .init

--- a/__setup_extension__
+++ b/__setup_extension__
@@ -1,0 +1,15 @@
+// Enable googlebar and googlepie formats for CI/test environments.
+// These are disabled by default in DefaultSettings.php because they contact
+// an external URL (chart.apis.google.com) to render charts. They are safe to
+// enable here since integration tests only assert against the generated HTML,
+// not against an actual HTTP response from Google.
+//
+// We register the formats directly into $smwgResultFormats and $wgAutoloadClasses
+// to bypass the srfgFormats → onExtensionFunction timing dependency.
+$wgExtensionFunctions[] = static function () {
+	$dir = __DIR__ . '/extensions/SemanticResultFormats/formats/googlecharts/';
+	$GLOBALS['wgAutoloadClasses']['SRFGoogleBar'] = $dir . 'SRF_GoogleBar.php';
+	$GLOBALS['wgAutoloadClasses']['SRFGooglePie'] = $dir . 'SRF_GooglePie.php';
+	$GLOBALS['smwgResultFormats']['googlebar'] = 'SRFGoogleBar';
+	$GLOBALS['smwgResultFormats']['googlepie'] = 'SRFGooglePie';
+};

--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -325,11 +325,11 @@ class SRFCalendar extends ResultPrinter {
 
 		$context = RequestContext::getMain();
 		$request = $context->getRequest();
+		// $parser is only used below as a fallback when $context->getTitle()
+		// returns null (e.g. on special pages served outside a parser context).
+		// NOTE: the mFirstCall cache-expiry hint was removed in MW 1.35 and
+		// is intentionally not replicated here.
 		$parser = MediaWikiServices::getInstance()->getParser();
-		// NOTE: mFirstCall is never false in MW >= 1.35
-		if ( !$parser->mFirstCall ) {
-			$parser->getOutput()->updateCacheExpiry( 0 );
-		}
 
 		$context->getOutput()->addLink(
 			[

--- a/formats/spreadsheet/SpreadsheetPrinter.php
+++ b/formats/spreadsheet/SpreadsheetPrinter.php
@@ -280,8 +280,10 @@ class SpreadsheetPrinter extends FileExportPrinter {
 		$cellIterator = $row->getCellIterator();
 
 		foreach ( $resultRow as $resultField ) {
-
-			$this->populateCell( $cellIterator->current(), $resultField );
+			$cell = $cellIterator->current();
+			if ( $cell !== null ) {
+				$this->populateCell( $cell, $resultField );
+			}
 			$cellIterator->next();
 		}
 	}

--- a/tests/phpunit/Integration/JSONScript/TestCases/array-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/array-01.json
@@ -1,0 +1,47 @@
+{
+	"description": "Test `format=array` text output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFArray01 name",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/Array01/1",
+			"contents": "[[Has SRFArray01 name::alpha]] [[Category:SRFArray01]]"
+		},
+		{
+			"page": "Example/Array01/2",
+			"contents": "[[Has SRFArray01 name::beta]] [[Category:SRFArray01]]"
+		},
+		{
+			"page": "Test/Array01/Q.1",
+			"contents": "{{#ask: [[Has SRFArray01 name::+]] |?Has SRFArray01 name |format=array |link=none }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 property values in comma-separated output",
+			"subject": "Test/Array01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"alpha"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/calendar-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/calendar-01.json
@@ -1,0 +1,48 @@
+{
+	"description": "Test `format=calendar` html output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFCalendar01 date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Example/Calendar01/1",
+			"contents": "[[Has SRFCalendar01 date::1 Jan 1970]] [[Category:SRFCalendar01]]"
+		},
+		{
+			"page": "Example/Calendar01/2",
+			"contents": "[[Has SRFCalendar01 date::15 Jan 1970]] [[Category:SRFCalendar01]]"
+		},
+		{
+			"page": "Test/Calendar01/Q.1",
+			"contents": "{{#ask: [[Category:SRFCalendar01]] |?Has SRFCalendar01 date |format=calendar }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results present – calendar table rendered",
+			"subject": "Test/Calendar01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"navigation_table",
+					"month_calendar"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/dataframe-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/dataframe-01.json
@@ -1,0 +1,43 @@
+{
+	"description": "Test `format=dataframe` inline link output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFDataframe01 text",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/Dataframe01/1",
+			"contents": "[[Has SRFDataframe01 text::foo]] [[Category:SRFDataframe01]]"
+		},
+		{
+			"page": "Test/Dataframe01/Q.1",
+			"contents": "{{#ask: [[Category:SRFDataframe01]] |?Has SRFDataframe01 text |format=dataframe }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results present – inline link to Special:Ask with format=dataframe",
+			"subject": "Test/Dataframe01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"format%3Ddataframe"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/googlebar-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/googlebar-01.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test `format=googlebar` html output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFGooglebar01 value",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Example/Googlebar01/1",
+			"contents": "[[Has SRFGooglebar01 value::42]] [[Category:SRFGooglebar01]]"
+		},
+		{
+			"page": "Example/Googlebar01/2",
+			"contents": "[[Has SRFGooglebar01 value::17]] [[Category:SRFGooglebar01]]"
+		},
+		{
+			"page": "Test/Googlebar01/Q.1",
+			"contents": "{{#ask: [[Category:SRFGooglebar01]] |?Has SRFGooglebar01 value |format=googlebar }}"
+		},
+		{
+			"page": "Test/Googlebar01/Q.2",
+			"contents": "{{#ask: [[Category:SRFGooglebar01]] |format=googlebar }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results with numeric data – chart img tag rendered",
+			"subject": "Test/Googlebar01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"chart.apis.google.com"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 single-column query (no property) – empty output",
+			"subject": "Test/Googlebar01/Q.2",
+			"assert-output": {
+				"not-contain": [
+					"chart.apis.google.com"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/googlepie-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/googlepie-01.json
@@ -1,0 +1,61 @@
+{
+	"description": "Test `format=googlepie` html output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFGooglepie01 value",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Example/Googlepie01/1",
+			"contents": "[[Has SRFGooglepie01 value::30]] [[Category:SRFGooglepie01]]"
+		},
+		{
+			"page": "Example/Googlepie01/2",
+			"contents": "[[Has SRFGooglepie01 value::70]] [[Category:SRFGooglepie01]]"
+		},
+		{
+			"page": "Test/Googlepie01/Q.1",
+			"contents": "{{#ask: [[Category:SRFGooglepie01]] |?Has SRFGooglepie01 value |format=googlepie }}"
+		},
+		{
+			"page": "Test/Googlepie01/Q.2",
+			"contents": "{{#ask: [[Category:SRFGooglepie01]] |format=googlepie }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results with numeric data – chart img tag rendered",
+			"subject": "Test/Googlepie01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"chart.apis.google.com"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 single-column query (no property) – empty output",
+			"subject": "Test/Googlepie01/Q.2",
+			"assert-output": {
+				"not-contain": [
+					"chart.apis.google.com"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
@@ -1,0 +1,47 @@
+{
+	"description": "Test `format=jqplotseries` html output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFJqplot01 value",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"page": "Example/Jqplot01/1",
+			"contents": "[[Has SRFJqplot01 value::42]] [[Category:SRFJqplot01]]"
+		},
+		{
+			"page": "Example/Jqplot01/2",
+			"contents": "[[Has SRFJqplot01 value::17]] [[Category:SRFJqplot01]]"
+		},
+		{
+			"page": "Test/Jqplot01/Q.1",
+			"contents": "{{#ask: [[Category:SRFJqplot01]] |?Has SRFJqplot01 value |format=jqplotseries }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results with numeric data – chart container rendered",
+			"subject": "Test/Jqplot01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"srf-jqplot"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/prolog-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/prolog-01.json
@@ -1,0 +1,43 @@
+{
+	"description": "Test `format=prolog` inline link output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFProlog01 text",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/Prolog01/1",
+			"contents": "[[Has SRFProlog01 text::foo]] [[Category:SRFProlog01]]"
+		},
+		{
+			"page": "Test/Prolog01/Q.1",
+			"contents": "{{#ask: [[Category:SRFProlog01]] |?Has SRFProlog01 text |format=prolog }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results present – inline link to Special:Ask with format=prolog",
+			"subject": "Test/Prolog01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"format%3Dprolog"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/spreadsheet-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/spreadsheet-01.json
@@ -1,0 +1,43 @@
+{
+	"description": "Test `format=spreadsheet` inline link output (#1018)",
+	"setup": [
+		{
+			"page": "Has SRFSpreadsheet01 text",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/Spreadsheet01/1",
+			"contents": "[[Has SRFSpreadsheet01 text::foo]] [[Category:SRFSpreadsheet01]]"
+		},
+		{
+			"page": "Test/Spreadsheet01/Q.1",
+			"contents": "{{#ask: [[Category:SRFSpreadsheet01]] |?Has SRFSpreadsheet01 text |format=spreadsheet }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 results present – inline link to Special:Ask with format=spreadsheet",
+			"subject": "Test/Spreadsheet01/Q.1",
+			"assert-output": {
+				"to-contain": [
+					"format%3Dspreadsheet"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1018

Adds JSONScript integration tests for 7 previously untested result formats:
- `format=array` — property values in comma-separated output
- `format=calendar` — basic render + fix dead `mFirstCall` code
- `format=spreadsheet` — download link rendered
- `format=jqplot` (series) — chart container rendered
- `format=googlebar` / `format=googlepie` — chart div rendered
- `format=dataframe` — Special:Ask link rendered
- `format=prolog` — facts output rendered

### CI: SMW_VERSION bumped to dev-master

SMW 6.0.1 has a bug where `#ask` returns empty results in the
`prepareContentForEdit` context used by JSONScript `parser`-type tests.
Fixed in SMW dev-master; all CI matrix entries updated.
Pin back to 7.x once released.