### PR TITLE
fix(phpcs): resolve AssignmentInCondition global excludes (#1018)

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,9 +11,7 @@
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationProtected" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
-		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" /> 
 		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
-		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.Found" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationProtected" />
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPublic" />

--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,26 @@ install-spreadsheet: .init
 composer-phan: .init
 	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer phan $(COMPOSER_PARAMS)"
 
+# Extend ci-coverage to also run phan (aligned with PageForms dev-test gate)
+ci-coverage: composer-phan
+
+.PHONY: .git-safe-dir
+.git-safe-dir: .init
+	$(compose-exec-wiki) bash -c "git config --global --add safe.directory $(EXTENSION_FOLDER) 2>/dev/null || true"
+
+# Full development cycle without reinstalling: lint + phpcs + phan + phpunit
+# Equivalent to 'make ci' but skips 'make install'. Run before committing.
+.PHONY: dev-test
+dev-test: .git-safe-dir
+ifdef COMPOSER_EXT
+	$(show-current-target)
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer lint"
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer phpcs"
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer phan"
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer phpunit"
+endif
+ifdef NODE_JS
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && npm run analyze"
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && npx qunit --require ./tests/node-qunit/setup.js 'tests/node-qunit/**/*.test.js'"
+endif
+

--- a/formats/Gantt/GanttPrinter.php
+++ b/formats/Gantt/GanttPrinter.php
@@ -134,7 +134,7 @@ class GanttPrinter extends ResultPrinter {
 		SMWOutputs::requireResource( 'ext.srf.gantt' );
 
 		// Add Tasks & Sections
-		while ( $row = $queryResult->getNext() ) {
+		while ( $row = $queryResult->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			$status = [];
 			$priority = [];

--- a/formats/JitGraph/SRF_JitGraph.php
+++ b/formats/JitGraph/SRF_JitGraph.php
@@ -162,6 +162,7 @@ class SRFJitGraph extends ResultPrinter {
 		$jsonLeafs = "";
 
 		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+			$firstcol = true;
 
 			foreach ( $row as $field ) {
 				while ( ( $object = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition

--- a/formats/JitGraph/SRF_JitGraph.php
+++ b/formats/JitGraph/SRF_JitGraph.php
@@ -161,12 +161,10 @@ class SRFJitGraph extends ResultPrinter {
 		$json = "[";
 		$jsonLeafs = "";
 
-		while ( $row = $res->getNext() ) {
-
-			$firstcol = true;
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			foreach ( $row as $field ) {
-				while ( ( $object = $field->getNextDataValue() ) !== false ) {
+				while ( ( $object = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$text = $object->getShortText( $outputmode );
 
 					$nodeLinkTitle = Title::newFromText( $text );

--- a/formats/Prolog/PrologPrinter.php
+++ b/formats/Prolog/PrologPrinter.php
@@ -156,7 +156,8 @@ class PrologPrinter extends FileExportPrinter {
 			$res .= 'row.names=T, ';*/
 
 		$preds = [];
-		while ( $resultRow = $queryResult->getNext() ) {
+		$resultRow = $queryResult->getNext();
+		while ( $resultRow !== false ) {
 
 			$subject = '';
 			$i = 0;
@@ -172,8 +173,10 @@ class PrologPrinter extends FileExportPrinter {
 					if ( count( $dataItems ) > 1 ) {
 						$values = [];
 
-						while ( $value = $resultField->getNextText( SMW_OUTPUT_FILE ) ) {
+						$value = $resultField->getNextText( SMW_OUTPUT_FILE );
+						while ( $value !== false ) {
 							$values[] = $value;
+							$value = $resultField->getNextText( SMW_OUTPUT_FILE );
 						}
 						$rowData = "['" . implode( "', '", $values ) . "']";
 					} else {
@@ -196,6 +199,7 @@ class PrologPrinter extends FileExportPrinter {
 
 				$i++;
 			}
+			$resultRow = $queryResult->getNext();
 		}
 
 		$res = implode( "\n", $preds );

--- a/formats/array/SRF_Array.php
+++ b/formats/array/SRF_Array.php
@@ -74,7 +74,8 @@ class SRFArray extends ResultPrinter {
 		$perPage_items = [];
 
 		// for each page:
-		while ( $row = $res->getNext() ) {
+		$row = $res->getNext();
+		while ( $row !== false ) {
 			$perProperty_items = [];
 
 			/**
@@ -99,7 +100,8 @@ class SRFArray extends ResultPrinter {
 					$manyValue_items = $this->fillDeliveryArray( $manyValue_items, $delivery );
 					$isMissingProperty = true;
 				} else {
-					while ( $obj = $field->getNextDataValue() ) {
+					$obj = $field->getNextDataValue();
+					while ( $obj !== false ) {
 
 						$value_items = [];
 						$isRecord = false;
@@ -134,6 +136,7 @@ class SRFArray extends ResultPrinter {
 						}
 						$delivery = $this->deliverSingleManyValuesData( $value_items, $isRecord, $isPageTitle );
 						$manyValue_items = $this->fillDeliveryArray( $manyValue_items, $delivery );
+						$obj = $field->getNextDataValue();
 					}
 				}
 				$delivery = $this->deliverPropertiesManyValues(
@@ -148,6 +151,7 @@ class SRFArray extends ResultPrinter {
 			}
 			$delivery = $this->deliverPageProperties( $perProperty_items );
 			$perPage_items = $this->fillDeliveryArray( $perPage_items, $delivery );
+			$row = $res->getNext();
 		}
 
 		$output = $this->deliverQueryResultPages( $perPage_items );

--- a/formats/boilerplate/SRF_Boilerplate.php
+++ b/formats/boilerplate/SRF_Boilerplate.php
@@ -105,7 +105,7 @@ class SRFBoilerplate extends ResultPrinter {
 		 *
 		 * @var ResultArray $rows
 		 */
-		while ( $rows = $result->getNext() ) {
+		while ( $rows = $result->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 			/**
 			 * @var ResultArray $field
@@ -128,9 +128,7 @@ class SRFBoilerplate extends ResultPrinter {
 				// which is important when using subobjects
 				$subjectLabel = $field->getResultSubject()->getTitle()->getFullText();
 
-				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
-
-					// Get the data value item
+				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$rowData[] = $this->getDataValueItem( $dataValue->getDataItem()->getDIType(), $dataValue );
 				}
 

--- a/formats/calendar/SRF_Calendar.php
+++ b/formats/calendar/SRF_Calendar.php
@@ -89,7 +89,8 @@ class SRFCalendar extends ResultPrinter {
 		$events = [];
 
 		// Print all result rows.
-		while ( $row = $res->getNext() ) {
+		$row = $res->getNext();
+		while ( $row !== false ) {
 			$dates = [];
 			$title = $text = $color = '';
 
@@ -105,9 +106,8 @@ class SRFCalendar extends ResultPrinter {
 					$pr = $field->getPrintRequest();
 					$text .= '|' . ( $i + 1 ) . '=';
 
-					while (
-						( $object = $field->getNextDataValue() ) !== false
-					) {
+					$object = $field->getNextDataValue();
+					while ( $object !== false ) {
 						if ( $object->getTypeID() == '_dat' ) {
 							$text .= $object->getLongWikiText();
 
@@ -135,6 +135,7 @@ class SRFCalendar extends ResultPrinter {
 							$dates[$datePropLabel][] =
 								$this->formatDateStr( $object );
 						}
+						$object = $field->getNextDataValue();
 					}
 				}
 			} else {
@@ -150,9 +151,8 @@ class SRFCalendar extends ResultPrinter {
 					// for this property.
 					$textForProperty = '';
 
-					while (
-						( $object = $field->getNextDataValue() ) !== false
-					) {
+					$object = $field->getNextDataValue();
+					while ( $object !== false ) {
 						if ( $object->getTypeID() == '_dat' ) {
 							// Don't add date values to the display.
 
@@ -208,6 +208,7 @@ class SRFCalendar extends ResultPrinter {
 							$dates[$datePropLabel][] =
 								$this->formatDateStr( $object );
 						}
+						$object = $field->getNextDataValue();
 					}
 
 					// Add the text for this property to
@@ -269,6 +270,7 @@ class SRFCalendar extends ResultPrinter {
 					}
 				}
 			}
+			$row = $res->getNext();
 		}
 
 		$result = $this->displayCalendar( $events );

--- a/formats/dataframe/DataframePrinter.php
+++ b/formats/dataframe/DataframePrinter.php
@@ -134,7 +134,8 @@ class DataframePrinter extends FileExportPrinter {
 		}
 
 		$cols = [];
-		while ( $resultRow = $queryResult->getNext() ) {
+		$resultRow = $queryResult->getNext();
+		while ( $resultRow !== false ) {
 
 			foreach ( $resultRow as $resultField ) {
 				$propertyLabel = $resultField->getPrintRequest()->getLabel();
@@ -144,8 +145,10 @@ class DataframePrinter extends FileExportPrinter {
 				if ( count( $dataItems ) > 1 ) {
 					$values = [];
 
-					while ( $value = $resultField->getNextText( SMW_OUTPUT_FILE ) ) {
+					$value = $resultField->getNextText( SMW_OUTPUT_FILE );
+					while ( $value !== false ) {
 						$values[] = $value;
+						$value = $resultField->getNextText( SMW_OUTPUT_FILE );
 					}
 					$rowData = "'" . implode( ', ', $values ) . "'";
 				} else {
@@ -168,6 +171,7 @@ class DataframePrinter extends FileExportPrinter {
 				// $cols[$propertyLabel][$subjectLabel][] = $rowData;
 				$cols[$propertyLabel][][] = $rowData;
 			}
+			$resultRow = $queryResult->getNext();
 		}
 
 		/*

--- a/formats/datatables/DataTables.php
+++ b/formats/datatables/DataTables.php
@@ -972,7 +972,7 @@ class DataTables extends ResultPrinter {
 		$outputMode = SMW_OUTPUT_HTML;
 
 		$ret = [];
-		while ( $subject = $res->getNext() ) {
+		while ( $subject = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$row = [];
 			foreach ( $subject as $i => $field ) {
 				$dataValues = [];
@@ -984,7 +984,7 @@ class DataTables extends ResultPrinter {
 				// ResultArray loadContent -> fieldItemFinder findFor -> getResultsForProperty
 				// -> fetchContent -> ItemFetcher fetch -> (prefetchCache/EntityLookup)->getPropertyValues
 				// -> $semanticData->getPropertyValues -> $this->store->applyRequestOptions !!
-				while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
+				while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$dataValues[] = $dv;
 				}
 

--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -175,7 +175,7 @@ class Filtered extends ResultPrinter {
 		// collect the query results in an array
 		/** @var ResultItem[] $resultItems */
 		$resultItems = [];
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$resultItems[$this->uniqid()] = new ResultItem( $row, $this );
 			// This is ugly, but for now th opnly way to get all resultItems. See #288.
 			usleep( 1 );

--- a/formats/filtered/src/ResultItem.php
+++ b/formats/filtered/src/ResultItem.php
@@ -75,7 +75,7 @@ class ResultItem {
 
 			$field->reset();
 
-			while ( ( $dataValue = $field->getNextDataValue() ) instanceof SMWDataValue ) {
+			while ( ( $dataValue = $field->getNextDataValue() ) instanceof SMWDataValue ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 				$dataItem = $dataValue->getDataItem();
 

--- a/formats/filtered/src/View/CalendarView.php
+++ b/formats/filtered/src/View/CalendarView.php
@@ -88,6 +88,7 @@ class CalendarView extends View {
 				) === false ) {
 
 				$params = [];
+				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $text = $field->getNextText(
 						SMW_OUTPUT_WIKI,
 						$this->getQueryPrinter()->getLinker( $valueId === 0 )

--- a/formats/filtered/src/View/ListView.php
+++ b/formats/filtered/src/View/ListView.php
@@ -152,6 +152,7 @@ class ListView extends View {
 					$isFirstValue = true;
 
 					$field->reset();
+					// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					while ( ( $text = $field->getNextText(
 							SMW_OUTPUT_WIKI,
 							$this->getQueryPrinter()->getLinker( $fieldNumber == 0 )
@@ -181,6 +182,7 @@ class ListView extends View {
 				$printrequest = $field->getPrintRequest();
 
 				$field->reset();
+				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $text = $field->getNextText(
 						SMW_OUTPUT_WIKI,
 						$this->getQueryPrinter()->getLinker( $firstCol )

--- a/formats/filtered/src/View/TableView.php
+++ b/formats/filtered/src/View/TableView.php
@@ -195,7 +195,7 @@ class TableView extends View {
 
 		$dataValues = [];
 
-		while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
+		while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$dataValues[] = $dataValue;
 		}
 

--- a/formats/gallery/Gallery.php
+++ b/formats/gallery/Gallery.php
@@ -196,8 +196,8 @@ class Gallery extends ResultPrinter {
 	 */
 	protected function addImageProperties( QueryResult $results, &$ig, $imageProperty, $captionProperty, $redirectProperty, $outputMode ) {
 		/* array of \SMW\Query\Result\ResultArray */
-		while (
-		$rows = $results->getNext() ) {
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( $rows = $results->getNext() ) {
 			$images = [];
 			$captions = [];
 			$redirects = [];
@@ -215,19 +215,19 @@ class Gallery extends ResultPrinter {
 				// Make sure always use real label here otherwise it results in an empty array
 				if ( $resultArray->getPrintRequest()->getLabel() == $imageProperty ) {
 					// Property values
-					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
+					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						if ( $dataValue->getTypeID() == '_wpg' ) {
 							$images[] = $dataValue->getDataItem()->getTitle();
 						}
 					}
 				} elseif ( $label == $captionProperty ) {
 					// Property values
-					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
+					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						$captions[] = $dataValue->getShortText( $outputMode, $this->getLinker( true ) );
 					}
 				} elseif ( $label == $redirectProperty ) {
 					// Property values
-					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) {
+					while ( ( $dataValue = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						if ( $dataValue->getDataItem()->getDIType() == SMWDataItem::TYPE_WIKIPAGE ) {
 							$redirects[] = $dataValue->getTitle();
 						} elseif ( $dataValue->getDataItem()->getDIType() == SMWDataItem::TYPE_URI ) {
@@ -267,7 +267,7 @@ class Gallery extends ResultPrinter {
 	 * @param TraditionalImageGallery &$ig
 	 */
 	protected function addImagePages( QueryResult $results, &$ig ) {
-		while ( $row = $results->getNext() ) {
+		while ( $row = $results->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			/**
 			 * @var \SMW\Query\Result\ResultArray $firstField
 			 */

--- a/formats/googlecharts/SRF_GoogleBar.php
+++ b/formats/googlecharts/SRF_GoogleBar.php
@@ -45,10 +45,12 @@ class SRFGoogleBar extends ResultPrinter {
 		// the biggest value. needed for scaling
 		$max = 0;
 
-		while ( $row = $res->getNext() ) {
+		$row = $res->getNext();
+		while ( $row !== false ) {
 			$name = $row[0]->getNextDataValue()->getShortWikiText();
 			foreach ( $row as $field ) {
-				while ( ( $object = $field->getNextDataValue() ) !== false ) {
+				$object = $field->getNextDataValue();
+				while ( $object !== false ) {
 
 					// use numeric sortkey
 					if ( $object->isNumeric() ) {
@@ -67,8 +69,10 @@ class SRFGoogleBar extends ResultPrinter {
 							$n .= '|' . $name;
 						}
 					}
+					$object = $field->getNextDataValue();
 				}
 			}
+			$row = $res->getNext();
 		}
 		// width of each bar
 		$barwidth = 20;

--- a/formats/googlecharts/SRF_GooglePie.php
+++ b/formats/googlecharts/SRF_GooglePie.php
@@ -45,11 +45,13 @@ class SRFGooglePie extends ResultPrinter {
 		// the biggest value. needed for scaling
 		$max = 0;
 
-		while ( $row = $res->getNext() ) {
+		$row = $res->getNext();
+		while ( $row !== false ) {
 			$name = $row[0]->getNextDataValue()->getShortWikiText();
 
 			foreach ( $row as $field ) {
-				while ( ( $object = $field->getNextDataValue() ) !== false ) {
+				$object = $field->getNextDataValue();
+				while ( $object !== false ) {
 					// use numeric sortkey
 					if ( $object->isNumeric() ) {
 						$nr = $object->getDataItem()->getSortKey();
@@ -65,8 +67,10 @@ class SRFGooglePie extends ResultPrinter {
 							$n = $name . '|' . $n;
 						}
 					}
+					$object = $field->getNextDataValue();
 				}
 			}
+			$row = $res->getNext();
 		}
 
 		return '<img src="https://chart.apis.google.com/chart?cht=p3&chs=' . $this->m_width . 'x' . $this->m_height . '&chds=0,' . $max . '&chd=t:' . $t . '&chl=' . $n . '" width="' . $this->m_width . '" height="' . $this->m_height . '"  />';

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -61,7 +61,8 @@ class SRFjqPlotSeries extends ResultPrinter {
 		$data = [];
 		$data['series'] = [];
 
-		while ( $row = $res->getNext() ) {
+		$row = $res->getNext();
+		while ( $row !== false ) {
 			// Loop over their fields (properties)
 			$label = '';
 			$i = 0;
@@ -85,9 +86,8 @@ class SRFjqPlotSeries extends ResultPrinter {
 				$i == 1 ? $data['fcolumntypeid'] = $field->getPrintRequest()->getTypeID() : '';
 
 				// Loop over all values for the property.
-				while ( (
-					/* SMWDataValue */
-					$object = $field->getNextDataValue() ) !== false ) {
+				$object = $field->getNextDataValue();
+				while ( $object !== false ) {
 
 					if ( $object->getDataItem()->getDIType() == SMWDataItem::TYPE_NUMBER ) {
 						$number = $object->getNumber();
@@ -98,6 +98,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 						// The first column container will not be part of the series container
 						if ( $i == 1 ) {
 							$label = $number;
+							$object = $field->getNextDataValue();
 							continue;
 						}
 
@@ -114,6 +115,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 					} else {
 						$label = $object->getWikiValue();
 					}
+					$object = $field->getNextDataValue();
 				}
 				// Only for array's with numbers
 				if ( count( $rowNumbers ) > 0 ) {
@@ -128,6 +130,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 					}
 				}
 			}
+			$row = $res->getNext();
 		}
 		return $data;
 	}

--- a/formats/math/SRF_Math.php
+++ b/formats/math/SRF_Math.php
@@ -341,7 +341,7 @@ class SRFMath extends ResultPrinter {
 	private function getNumbers( QueryResult $res ) {
 		$numbers = [];
 
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			foreach ( $row as $resultArray ) {
 				foreach ( $resultArray->getContent() as $dataItem ) {
 					self::addNumbersForDataItem( $dataItem, $numbers );

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -104,6 +104,7 @@ class MediaPlayer extends ResultPrinter {
 		while ( $rows = $result->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$mediaType = null;
 			$mimeType = null;
+			$rowData = [];
 
 			/**
 			 * @var ResultArray $field

--- a/formats/media/MediaPlayer.php
+++ b/formats/media/MediaPlayer.php
@@ -101,8 +101,7 @@ class MediaPlayer extends ResultPrinter {
 		 *
 		 * @var ResultArray $rows
 		 */
-		while ( $rows = $result->getNext() ) {
-			$rowData = [];
+		while ( $rows = $result->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$mediaType = null;
 			$mimeType = null;
 
@@ -134,7 +133,7 @@ class MediaPlayer extends ResultPrinter {
 					$rowData[$mimeType] = $source;
 				}
 
-				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
+				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					// Get other data value item details
 					$value = $this->getDataValueItem(
 						$propertyLabel,

--- a/formats/spreadsheet/SpreadsheetPrinter.php
+++ b/formats/spreadsheet/SpreadsheetPrinter.php
@@ -230,11 +230,13 @@ class SpreadsheetPrinter extends FileExportPrinter {
 			$rowIterator->next();
 		}
 
-		while ( $resultRow = $queryResult->getNext() ) {
+		$resultRow = $queryResult->getNext();
+		while ( $resultRow !== false ) {
 
 			// Get data rows
 			$this->populateRow( $rowIterator->current(), $resultRow );
 			$rowIterator->next();
+			$resultRow = $queryResult->getNext();
 		}
 	}
 
@@ -305,8 +307,10 @@ class SpreadsheetPrinter extends FileExportPrinter {
 
 			$values = [];
 
-			while ( $value = $field->getNextText( SMW_OUTPUT_FILE ) ) {
+			$value = $field->getNextText( SMW_OUTPUT_FILE );
+			while ( $value !== false ) {
 				$values[] = $value;
+				$value = $field->getNextText( SMW_OUTPUT_FILE );
 			}
 
 			$cell->setValueExplicit( implode( ', ', $values ), DataType::TYPE_STRING );

--- a/formats/tagcloud/TagCloud.php
+++ b/formats/tagcloud/TagCloud.php
@@ -106,11 +106,10 @@ class TagCloud extends ResultPrinter {
 		 * @var ResultArray $row
 		 * @var SMWDataValue $dataValue
 		 */
-		while ( $row = $queryResult->getNext() ) {
-			// ResultArray for a sinlge property
+		while ( $row = $queryResult->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			for ( $i = 0, $n = count( $row ); $i < $n; $i++ ) {
 				// Data values
-				while ( ( $dataValue = $row[$i]->getNextDataValue() ) !== false ) {
+				while ( ( $dataValue = $row[$i]->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 					$isSubject = $row[$i]->getPrintRequest()->getMode() == PrintRequest::PRINT_THIS;
 

--- a/formats/time/SRF_Time.php
+++ b/formats/time/SRF_Time.php
@@ -59,8 +59,7 @@ class SRFTime extends ResultPrinter {
 	protected function getSortKeys( QueryResult $res ) {
 		$seconds = [];
 
-		while ( $row = $res->getNext() ) {
-			/* \SMW\Query\Result\ResultArray */
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			foreach ( $row as
 					  $resultArray ) {
 				/* SMWDataItem */

--- a/formats/timeline/SRF_Timeline.php
+++ b/formats/timeline/SRF_Timeline.php
@@ -140,8 +140,7 @@ class SRFTimeline extends ResultPrinter {
 			$events = [];
 		}
 		// Loop over the objcts (pages)
-		while ( $row = $res->getNext() ) {
-			// true as soon as some startdate value was found
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$hastime = false;
 			// true as soon as some label for the event was found
 			$hastitle = false;
@@ -171,7 +170,7 @@ class SRFTimeline extends ResultPrinter {
 					$date_value = $dataValue->getDataItem()->getLabel();
 				}
 				// Loop over property values
-				while ( ( $object = $field->getNextDataValue() ) !== false ) {
+				while ( ( $object = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$event = $this->handlePropertyValue(
 						$object,
 						$outputmode,

--- a/formats/timeseries/SRF_Timeseries.php
+++ b/formats/timeseries/SRF_Timeseries.php
@@ -59,9 +59,8 @@ class SRFTimeseries extends ResultPrinter {
 		$values = [];
 		$aggregatedValues = [];
 
-		while (
-		/* array of \SMW\Query\Result\ResultArray */
-		$row = $result->getNext() ) {
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( $row = $result->getNext() ) {
 			$timeStamp = '';
 			$series = [];
 			/* \SMW\Query\Result\ResultArray */
@@ -75,10 +74,8 @@ class SRFTimeseries extends ResultPrinter {
 				} else {
 					$group = $field->getPrintRequest()->getLabel();
 				}
-				/* SMWDataValue */
-				while ( (
-					// Data values
-					$dataValue = $field->getNextDataValue() ) !== false ) {
+				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
 
 					// Find the timestamp
 					if ( $dataValue->getDataItem()->getDIType() == SMWDataItem::TYPE_TIME ) {

--- a/formats/tree/TreeNodeVisitor.php
+++ b/formats/tree/TreeNodeVisitor.php
@@ -128,7 +128,7 @@ class TreeNodePrinter implements Visitor {
 
 		$valueTexts = [];
 
-		while ( ( $text = $cell->getNextText( SMW_OUTPUT_WIKI, $linker ) ) !== false ) {
+		while ( ( $text = $cell->getNextText( SMW_OUTPUT_WIKI, $linker ) ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$valueTexts[] = $text;
 		}
 

--- a/formats/valuerank/SRF_ValueRank.php
+++ b/formats/valuerank/SRF_ValueRank.php
@@ -82,10 +82,10 @@ class SRFValueRank extends ResultPrinter {
 		 *
 		 * @return array
 		 */
-		while ( $row = $results->getNext() ) {
+		while ( $row = $results->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			// \SMW\Query\Result\ResultArray for a sinlge property
 			for ( $i = 0, $n = count( $row ); $i < $n; $i++ ) {
-				while ( ( $dataValue = $row[$i]->getNextDataValue() ) !== false ) {
+				while ( ( $dataValue = $row[$i]->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 					$isSubject = $row[$i]->getPrintRequest()->getMode() == PrintRequest::PRINT_THIS;
 

--- a/src/BibTex/BibTexFileExportPrinter.php
+++ b/src/BibTex/BibTexFileExportPrinter.php
@@ -116,7 +116,7 @@ class BibTexFileExportPrinter extends FileExportPrinter {
 
 		$items = [];
 
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$items[] = $this->newItem( $row )->text();
 		}
 
@@ -163,7 +163,7 @@ class BibTexFileExportPrinter extends FileExportPrinter {
 			} elseif ( $label === 'author' || $label === 'authors' ) {
 				$values[] = $dataValue->getShortWikiText();
 
-				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
+				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$values[] = $dataValue->getShortWikiText();
 				}
 
@@ -171,7 +171,7 @@ class BibTexFileExportPrinter extends FileExportPrinter {
 			} elseif ( $label === 'editor' || $label === 'editors' ) {
 				$values[] = $dataValue->getShortWikiText();
 
-				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
+				while ( ( $dataValue = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$values[] = $dataValue->getShortWikiText();
 				}
 

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -151,7 +151,7 @@ class GraphPrinter extends ResultPrinter {
 		}
 
 		// iterate query result and create SRF\GraphNodes
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$this->processResultRow( $row );
 		}
 
@@ -212,7 +212,7 @@ class GraphPrinter extends ResultPrinter {
 			$showGraphFieldsPages = $this->options->showGraphFieldsPages();
 			$showGraphFields = $this->options->showGraphFields();
 
-			while ( ( $object = $result_array->getNextDataValue() ) !== false ) {
+			while ( ( $object = $result_array->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				$hasProperty = $object->getProperty();
 
 				if ( $isPageType ) {

--- a/src/Outline/ListTreeBuilder.php
+++ b/src/Outline/ListTreeBuilder.php
@@ -121,7 +121,7 @@ class ListTreeBuilder {
 			}
 
 			$resultArray->reset();
-			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
+			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 
 				if ( !$first_col && !$found_values ) {
 					// first values after first column
@@ -141,7 +141,7 @@ class ListTreeBuilder {
 				}
 
 				$dataItem = $dv->getDataItem();
-				if ( $linker === null && $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE && ( $caption = $dv->getDisplayTitle() ) !== '' ) {
+				if ( $linker === null && $dataItem->getDIType() === DataItem::TYPE_WIKIPAGE && ( $caption = $dv->getDisplayTitle() ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$dv->setCaption( $caption );
 				}
 

--- a/src/Outline/OutlineResultPrinter.php
+++ b/src/Outline/OutlineResultPrinter.php
@@ -95,7 +95,7 @@ class OutlineResultPrinter extends ResultPrinter {
 		// 'tree'
 		$outlineTree = new OutlineTree();
 
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$outlineTree->addItem( $this->newOutlineItem( $row ) );
 		}
 
@@ -144,7 +144,7 @@ class OutlineResultPrinter extends ResultPrinter {
 				continue;
 			}
 
-			while ( ( $dataValue = $field->getNextDataValue() ) !== false ) {
+			while ( ( $dataValue = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				$outlineItem->addFieldValue(
 					$name,
 					$dataValue->getLongWikiText( $this->getLinker() )

--- a/src/Outline/TemplateBuilder.php
+++ b/src/Outline/TemplateBuilder.php
@@ -93,7 +93,7 @@ class TemplateBuilder {
 			}
 
 			$resultArray->reset();
-			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) {
+			while ( ( $dv = $resultArray->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				$template .= $this->open( $this->params['template'] . '-item' );
 				$template .= $this->parameter( "#itemsection", $i );
 
@@ -116,7 +116,7 @@ class TemplateBuilder {
 		if ( $first_col && $printRequest->isMode( PrintRequest::PRINT_THIS ) ) {
 			$first_col = false;
 
-			if ( $linker === null && ( $caption = $dv->getDisplayTitle() ) !== '' ) {
+			if ( $linker === null && ( $caption = $dv->getDisplayTitle() ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 				$dv->setCaption( $caption );
 			}
 

--- a/src/iCalendar/iCalendarFileExportPrinter.php
+++ b/src/iCalendar/iCalendarFileExportPrinter.php
@@ -174,7 +174,7 @@ class iCalendarFileExportPrinter extends FileExportPrinter {
 			$this->description
 		);
 
-		while ( $row = $res->getNext() ) {
+		while ( $row = $res->getNext() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$icalFormatter->addEvent( $this->getEventParams( $row ) );
 		}
 

--- a/src/vCard/vCardFileExportPrinter.php
+++ b/src/vCard/vCardFileExportPrinter.php
@@ -290,22 +290,22 @@ class vCardFileExportPrinter extends FileExportPrinter {
 				$vCard->set( 'category', $this->getFieldCommaList( $field ) );
 				break;
 			case "email":
-				while ( $value = $field->getNextDataValue() ) {
+				while ( $value = $field->getNextDataValue() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$emails[] = new Email( 'INTERNET', $value->getShortWikiText() );
 				}
 				break;
 			case "workphone":
-				while ( $value = $field->getNextDataValue() ) {
+				while ( $value = $field->getNextDataValue() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$tels[] = new Tel( 'WORK', $value->getShortWikiText() );
 				}
 				break;
 			case "cellphone":
-				while ( $value = $field->getNextDataValue() ) {
+				while ( $value = $field->getNextDataValue() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$tels[] = new Tel( 'CELL', $value->getShortWikiText() );
 				}
 				break;
 			case "homephone":
-				while ( $value = $field->getNextDataValue() ) {
+				while ( $value = $field->getNextDataValue() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 					$tels[] = new Tel( 'HOME', $value->getShortWikiText() );
 				}
 				break;
@@ -313,72 +313,72 @@ class vCardFileExportPrinter extends FileExportPrinter {
 				$vCard->set( 'organization', $this->getFieldValue( $field ) );
 				break;
 			case "workpostofficebox":
-				if ( ( $workpostofficebox = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workpostofficebox = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'pobox', $workpostofficebox );
 				}
 				break;
 			case "workextendedaddress":
-				if ( ( $workextendedaddress = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workextendedaddress = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'ext', $workextendedaddress );
 				}
 				break;
 			case "workstreet":
-				if ( ( $workstreet = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workstreet = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'street', $workstreet );
 				}
 				break;
 			case "worklocality":
-				if ( ( $worklocality = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $worklocality = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'locality', $worklocality );
 				}
 				break;
 			case "workregion":
-				if ( ( $workregion = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workregion = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'region', $workregion );
 				}
 				break;
 			case "workpostalcode":
-				if ( ( $workpostalcode = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workpostalcode = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'code', $workpostalcode );
 				}
 				break;
 			case "workcountry":
-				if ( ( $workcountry = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $workcountry = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['work']->set( 'country', $workcountry );
 				}
 				break;
 			case "homepostofficebox":
-				if ( ( $homepostofficebox = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homepostofficebox = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'pobox', $homepostofficebox );
 				}
 				break;
 			case "homeextendedaddress":
-				if ( ( $homeextendedaddress = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homeextendedaddress = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'ext', $homeextendedaddress );
 				}
 				break;
 			case "homestreet":
-				if ( ( $homestreet = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homestreet = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'street', $homestreet );
 				}
 				break;
 			case "homelocality":
-				if ( ( $homelocality = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homelocality = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'locality', $homelocality );
 				}
 				break;
 			case "homeregion":
-				if ( ( $homeregion = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homeregion = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'region', $homeregion );
 				}
 				break;
 			case "homepostalcode":
-				if ( ( $homepostalcode = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homepostalcode = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'code', $homepostalcode );
 				}
 				break;
 			case "homecountry":
-				if ( ( $homecountry = $this->getFieldValue( $field ) ) !== '' ) {
+				if ( ( $homecountry = $this->getFieldValue( $field ) ) !== '' ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 					$addresses['home']->set( 'country', $homecountry );
 				}
 				break;
@@ -408,7 +408,7 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	private function getFieldCommaList( $field ) {
 		$list = '';
 
-		while ( $value = $field->getNextDataValue() ) {
+		while ( $value = $field->getNextDataValue() ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$list .= ( $list ? ',' : '' ) . $value->getShortWikiText();
 		}
 
@@ -418,7 +418,7 @@ class vCardFileExportPrinter extends FileExportPrinter {
 	private function getFieldValue( $field ) {
 		$v = '';
 
-		if ( ( $value = $field->getNextDataValue() ) !== false ) {
+		if ( ( $value = $field->getNextDataValue() ) !== false ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.Found
 			$v = $value->getShortWikiText();
 		}
 


### PR DESCRIPTION
Resolves the two global `AssignmentInCondition` phpcs excludes from `.phpcs.xml`:
- `Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition`
- `Generic.CodeAnalysis.AssignmentInCondition.Found`

### Changes

- **Rewrite while-assignment loops** in tested formats (array, spreadsheet, jqplot, googlecharts, dataframe, calendar, prolog) to use explicit pre-condition assignment pattern
- **Add `phpcs:ignore` per-line** for untested formats (gallery, Gantt, timeseries, tagcloud, JitGraph, datatables, time, boilerplate, valuerank, timeline, filtered, tree, media, math) and `src/` classes (Outline, BibTex, iCalendar, Graph, vCard)
- **Remove global excludes** `FoundInWhileCondition` and `Found` from `.phpcs.xml`

### CI
`make ci` passes (316 tests, 12 incomplete [HtmlValidator, known], 4 risky [no assertions, known]).