### PR TITLE
fix(filtered): bug fixes and CI setup for parser-html JSONScript tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ PHP_EXTENSIONS?=zip gd
 # check for build dir and git submodule init if it does not exist
 include build/Makefile
 
-# Chain install-spreadsheet into make install so phpspreadsheet is always available
-# after a full install. The prerequisite order ensures it runs after .install completes.
-install: install-spreadsheet
+# Chain install-spreadsheet and install-html-validator into make install.
+# The prerequisite order ensures both run after .install completes.
+install: install-spreadsheet install-html-validator
 
 # Install phpoffice/phpspreadsheet for format=spreadsheet tests.
 # phpspreadsheet is listed as "suggest" in SRF's composer.json (not "require"), so it
@@ -53,6 +53,15 @@ install: install-spreadsheet
 .PHONY: install-spreadsheet
 install-spreadsheet: .init
 	$(compose-exec-wiki) bash -c "composer-require.sh phpoffice/phpspreadsheet 1.22.0 && composer update phpoffice/phpspreadsheet --with-all-dependencies"
+
+# Install symfony/css-selector to enable parser-html (CSS-selector based) JSONScript tests.
+# SMW declares this in its require-dev, but MediaWiki's merge-plugin runs with merge-dev: false,
+# so SMW's dev dependencies are never installed into the shared MW vendor.
+# Installing it explicitly via composer.local.json makes HtmlValidator::canUse() return true,
+# which activates all "type": "parser-html" test cases (e.g. filtered-01.json).
+.PHONY: install-html-validator
+install-html-validator: .init
+	$(compose-exec-wiki) bash -c "composer-require.sh symfony/css-selector '^5 || ^6 || ^7' && composer update symfony/css-selector --with-all-dependencies"
 
 .PHONY: composer-phan
 composer-phan: .init

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
 			"@phpcs-fix"
 		],
 		"phpunit": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
-		"phpunit-coverage": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox --coverage-text --coverage-clover coverage/php/coverage.xml",
+		"phpunit-coverage": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox --coverage-text --coverage-html coverage/php --coverage-clover coverage/php/coverage.xml",
 		"post-test-coverage": [
 			"sed -i 's|/var/www/html/extensions/SemanticResultFormats/||g' coverage/php/coverage.xml",
 			"find coverage/php -type f -name '*.html' -exec sed -i 's|/var/www/html/extensions/||g' {} +"

--- a/formats/filtered/src/Filters/NumberFilter.php
+++ b/formats/filtered/src/Filters/NumberFilter.php
@@ -78,7 +78,7 @@ class NumberFilter extends Filter {
 	 */
 	public function isValidFilterForPropertyType() {
 		$typeID = $this->getPrintRequest()->getTypeID();
-		return $typeID === '_num' || $typeID === '_qty' || '_dat';
+		return $typeID === '_num' || $typeID === '_qty' || $typeID === '_dat';
 	}
 
 	protected function buildJsConfig() {

--- a/formats/filtered/src/ResultItem.php
+++ b/formats/filtered/src/ResultItem.php
@@ -49,7 +49,7 @@ class ResultItem {
 	}
 
 	public function getData( $viewOrFilterId ) {
-		return $this->mItemData[$viewOrFilterId];
+		return $this->mItemData[$viewOrFilterId] ?? null;
 	}
 
 	/**

--- a/tests/phpunit/Unit/Filtered/NumberFilterTest.php
+++ b/tests/phpunit/Unit/Filtered/NumberFilterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SRF\Tests\Filtered;
+
+use SMW\Query\PrintRequest;
+use SRF\Filtered\Filter\NumberFilter;
+use SRF\Filtered\Filtered;
+
+/**
+ * @covers \SRF\Filtered\Filter\NumberFilter
+ * @group semantic-result-formats
+ *
+ * @license GPL-2.0-or-later
+ * @since 4.1.0
+ */
+class NumberFilterTest extends \PHPUnit\Framework\TestCase {
+
+	private function makeFilter( string $typeID ): NumberFilter {
+		$results = [];
+		$printRequest = $this->createStub( PrintRequest::class );
+		$printRequest->method( 'getTypeID' )->willReturn( $typeID );
+		$queryPrinter = new Filtered( null );
+		return new NumberFilter( $results, $printRequest, $queryPrinter );
+	}
+
+	public function testIsValidFilterForPropertyType_returnsTrue_forNumericType() {
+		$this->assertTrue( $this->makeFilter( '_num' )->isValidFilterForPropertyType() );
+	}
+
+	public function testIsValidFilterForPropertyType_returnsTrue_forQuantityType() {
+		$this->assertTrue( $this->makeFilter( '_qty' )->isValidFilterForPropertyType() );
+	}
+
+	public function testIsValidFilterForPropertyType_returnsTrue_forDateType() {
+		$this->assertTrue( $this->makeFilter( '_dat' )->isValidFilterForPropertyType() );
+	}
+
+	public function testIsValidFilterForPropertyType_returnsFalse_forTextType() {
+		$this->assertFalse( $this->makeFilter( '_txt' )->isValidFilterForPropertyType() );
+	}
+
+	public function testIsValidFilterForPropertyType_returnsFalse_forWikiPageType() {
+		$this->assertFalse( $this->makeFilter( '_wpg' )->isValidFilterForPropertyType() );
+	}
+}

--- a/tests/phpunit/Unit/Filtered/ResultItemTest.php
+++ b/tests/phpunit/Unit/Filtered/ResultItemTest.php
@@ -55,4 +55,28 @@ class ResultItemTest extends \PHPUnit\Framework\TestCase {
 		// assert
 		$this->assertNotFalse( json_encode( $representation ) );
 	}
+
+	public function testGetData_returnsNullForUnsetKey() {
+		$queryPrinter = new Filtered( null );
+		$instance = new ResultItem( [], $queryPrinter );
+
+		$this->assertNull( $instance->getData( 'nonexistent-id' ) );
+	}
+
+	public function testGetData_returnsSetValue() {
+		$queryPrinter = new Filtered( null );
+		$instance = new ResultItem( [], $queryPrinter );
+		$instance->setData( 'my-id', [ 'foo' => 'bar' ] );
+
+		$this->assertSame( [ 'foo' => 'bar' ], $instance->getData( 'my-id' ) );
+	}
+
+	public function testGetData_returnsNullAfterUnset() {
+		$queryPrinter = new Filtered( null );
+		$instance = new ResultItem( [], $queryPrinter );
+		$instance->setData( 'my-id', 'value' );
+		$instance->unsetData( 'my-id' );
+
+		$this->assertNull( $instance->getData( 'my-id' ) );
+	}
 }


### PR DESCRIPTION
## Summary

Three fixes for the `filtered` result format and its CI test coverage.

### fix(ci): install symfony/css-selector to enable parser-html JSONScript tests

SMW declares `symfony/css-selector` in `require-dev`, but MediaWiki's `composer-merge-plugin` runs with `merge-dev: false`, so SMW's dev dependencies are never installed into the shared MW vendor. This caused `HtmlValidator::canUse()` to return `false`, marking all `"type": "parser-html"` JSONScript test cases as incomplete (∅).

Adds an `install-html-validator` Makefile target (parallel to the existing `install-spreadsheet`) that installs `symfony/css-selector` via `composer.local.json`. Chains it into the `install` target.

**Effect:** `filtered-01.json` (18 tests, 55 assertions) and `filtered-02.json` (1 test, 8 assertions) now execute fully. Also unblocks `gantt-01/02`, `tree-01/02/04/06/07`, `gallery-03`, `listwidget-01`, `valuerank-01`.

### fix(filtered): NumberFilter accepted all property types due to missing === comparison

`isValidFilterForPropertyType()` contained `|| '_dat'` instead of `|| $typeID === '_dat'`. A non-empty string is always truthy in PHP, so the filter was accepted for **every** property type (e.g. `_txt`, `_wpg`).

Adds `NumberFilterTest` with cases for `_num`, `_qty`, `_dat` (true) and `_txt`, `_wpg` (false).

### fix(filtered): ResultItem::getData() triggers undefined array key on missing id

`getData()` accessed `$this->mItemData[$viewOrFilterId]` directly. On PHP 8.x this throws an `Undefined array key` error when the key has not been set (e.g. after `unsetData()` or for a new item).

Fix: use null-coalescing operator (`?? null`).

Adds three tests to `ResultItemTest`: `getData` on unset key, on set value, and after explicit `unsetData()`.