### PR TITLE
refactor(filtered): cleanup dead code and style issues

### DIFF
--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -218,9 +218,6 @@ class Filtered extends ResultPrinter {
 		$link->setCaption( Message::get( "srf-filtered-noscript-link-caption" ) );
 		$link->setParameter( 'table', 'format' );
 
-		SMWOutputs::requireResource( 'ext.srf.filtered' );
-		$this->registerResources( [], [ 'ext.srf.filtered' ] );
-
 		return $html;
 	}
 
@@ -301,7 +298,9 @@ class Filtered extends ResultPrinter {
 	 * @param string | string[] | null $resourceModules
 	 */
 	protected function registerResourceModules( $resourceModules ) {
-		array_map( 'SMWOutputs::requireResource', (array)$resourceModules );
+		foreach ( (array)$resourceModules as $module ) {
+			SMWOutputs::requireResource( $module );
+		}
 	}
 
 	/**

--- a/formats/filtered/src/Hooks.php
+++ b/formats/filtered/src/Hooks.php
@@ -15,12 +15,10 @@ class Hooks {
 
 	public static function onOutputPageParserOutput( OutputPage &$outputPage, ParserOutput $parserOutput ) {
 		$outputPage->setProperty( 'srf-filtered-config', $parserOutput->getExtensionData( 'srf-filtered-config' ) );
-		return true;
 	}
 
 	public static function onMakeGlobalVariablesScript( &$vars, OutputPage $output ) {
 		$vars['srfFilteredConfig'] = $output->getProperty( 'srf-filtered-config' );
-		return true;
 	}
 
 }

--- a/formats/filtered/src/View/CalendarView.php
+++ b/formats/filtered/src/View/CalendarView.php
@@ -102,7 +102,6 @@ class CalendarView extends View {
 
 		// only add to title template if requested and if not hidden
 		if ( $this->titleTemplate !== null ) {
-// $wikitext .= "|#=$rownum";
 			$data['title'] = trim(
 				$this->getQueryPrinter()->getParser()->recursiveTagParse(
 					'{{' . $this->titleTemplate . $wikitext . '}}'
@@ -141,18 +140,6 @@ class CalendarView extends View {
 			$this->titleTemplate = trim( $parser->recursiveTagParse( $params['calendar view title template'] ) );
 		}
 
-// $this->mTemplate = $params['list view template'];
-//		$this->mIntroTemplate = $params['list view introtemplate'];
-//		$this->mOutroTemplate = $params['list view outrotemplate'];
-//		$this->mNamedArgs = $params['list view named args'];
-//
-//		if ( $params['headers'] == 'hide' ) {
-//			$this->mShowHeaders = SMW_HEADERS_HIDE;
-//		} elseif ( $params['headers'] == 'plain' ) {
-//			$this->mShowHeaders = SMW_HEADERS_PLAIN;
-//		} else {
-//			$this->mShowHeaders = SMW_HEADERS_SHOW;
-//		}
 	}
 
 	/**

--- a/formats/filtered/src/View/CalendarView.php
+++ b/formats/filtered/src/View/CalendarView.php
@@ -139,7 +139,6 @@ class CalendarView extends View {
 		if ( $params['calendar view title template'] !== '' ) {
 			$this->titleTemplate = trim( $parser->recursiveTagParse( $params['calendar view title template'] ) );
 		}
-
 	}
 
 	/**

--- a/formats/filtered/src/View/MapView.php
+++ b/formats/filtered/src/View/MapView.php
@@ -17,7 +17,7 @@ class MapView extends View {
 	private $mapProviderDark = null;
 
 	/**
-	 * @param null $mapProvider
+	 * @param string $mapProvider
 	 */
 	public function setMapProvider( $mapProvider ) {
 		$this->mapProvider = $mapProvider;
@@ -28,14 +28,14 @@ class MapView extends View {
 	 */
 	public function getMapProvider() {
 		if ( $this->mapProvider === null ) {
-			$this->setMapProvider( isset( $GLOBALS['srfgMapProvider'] ) ? $GLOBALS['srfgMapProvider'] : '' );
+			$this->setMapProvider( $GLOBALS['srfgMapProvider'] ?? '' );
 		}
 
 		return $this->mapProvider;
 	}
 
 	/**
-	 * @param null $mapProviderDark
+	 * @param string $mapProviderDark
 	 */
 	public function setMapProviderDark( $mapProviderDark ) {
 		$this->mapProviderDark = $mapProviderDark;
@@ -43,7 +43,7 @@ class MapView extends View {
 
 	public function getMapProviderDark() {
 		if ( $this->mapProviderDark === null ) {
-			$this->setMapProviderDark( isset( $GLOBALS['srfgMapProviderDark'] ) ? $GLOBALS['srfgMapProviderDark'] : '' );
+			$this->setMapProviderDark( $GLOBALS['srfgMapProviderDark'] ?? '' );
 		}
 
 		return $this->mapProviderDark;

--- a/formats/filtered/src/View/TableView.php
+++ b/formats/filtered/src/View/TableView.php
@@ -87,7 +87,7 @@ class TableView extends View {
 		$queryResults = $this->getQueryResults();
 		$queryResultValue = reset( $queryResults );
 
-		if ( !is_a( $queryResultValue, ResultItem::class ) ) {
+		if ( !( $queryResultValue instanceof ResultItem ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
Closes #1024

Pure cleanup — no behaviour changes. All items verified by running the full test suite (324 tests, 972 assertions, same 6 pre-existing risky) and phan before committing.

### Changes

**F-03** — Remove duplicate `SMWOutputs::requireResource('ext.srf.filtered')` call and the redundant `registerResources([], ['ext.srf.filtered'])` that followed it in `Filtered::getResultText()`.

**F-06** — Simplify `$GLOBALS` access in `MapView::getMapProvider()` / `getMapProviderDark()` using `??` operator instead of `isset() ? : ''`. Also fix incorrect `@param null` docblocks on the setters to correctly declare `string`.

**F-10 / F-11** — Remove two dead commented-out code blocks in `CalendarView`:
- 12-line ListView copy-paste remnant in `handleParameters()`
- Stale `// $wikitext .= "|#=$rownum";` debug line in `getJsDataForRow()`

**F-13** — Replace legacy `!is_a($val, ResultItem::class)` with `!($val instanceof ResultItem)` in `TableView::getTableHeaders()`.

**F-14** — Replace `array_map('SMWOutputs::requireResource', ...)` (used only for side-effects, return value discarded) with a `foreach` loop in `Filtered::registerResourceModules()`.

**F-16** — Remove obsolete `return true` from `Hooks::onOutputPageParserOutput()` and `Hooks::onMakeGlobalVariablesScript()`. MW 1.35+ ignores boolean hook return values.