### PR TITLE
fix(filtered): replace global $wgAmericanDates with MainConfigNames (F-09)

### DIFF
--- a/formats/filtered/src/View/CalendarView.php
+++ b/formats/filtered/src/View/CalendarView.php
@@ -10,6 +10,7 @@ namespace SRF\Filtered\View;
  * @ingroup SemanticResultFormats
  */
 
+use MediaWiki\MainConfigNames;
 use MediaWiki\MediaWikiServices;
 use Message;
 use SRF\Filtered\ResultItem;
@@ -199,11 +200,11 @@ class CalendarView extends View {
 	 * @return string[]
 	 */
 	public function getJsConfig() {
-		global $wgAmericanDates;
+		$americanDates = MediaWikiServices::getInstance()->getMainConfig()->get( MainConfigNames::AmericanDates );
 
 		return $this->getParamHashes( $this->getQueryResults(), $this->getActualParameters() ) +
 			[
-				'firstDay' => ( $wgAmericanDates ? '0' : Message::newFromKey(
+				'firstDay' => ( $americanDates ? '0' : Message::newFromKey(
 					'srf-filtered-firstdayofweek'
 				)->inContentLanguage()->text() ),
 				'isRTL' => MediaWikiServices::getInstance()->getContentLanguage()->isRTL(),


### PR DESCRIPTION
Replace the deprecated `global $wgAmericanDates` access with the modern `MediaWikiServices::getInstance()->getMainConfig()->get( MainConfigNames::AmericanDates )`.

Global config variable access is deprecated in favour of the Config service. `MainConfigNames::AmericanDates` is available since MW 1.39.