### PR TITLE
refactor(filtered): lazy-init handleParameters() via null-guard in ListView (F-12)

### DIFF
--- a/formats/filtered/src/View/ListView.php
+++ b/formats/filtered/src/View/ListView.php
@@ -34,13 +34,19 @@ class ListView extends View {
 	private $mShowHeaders;
 	private $mUserParam;
 
-	/** @var array */
+	/** @var array|null */
 	private $params;
 
 	/**
 	 * Transfers the parameters applicable to this view into internal variables.
+	 * Lazy initialisation: both getJsConfig() and getResultText() call this method;
+	 * the null-check on $this->params ensures parameters are read only once.
 	 */
 	protected function handleParameters(): void {
+		if ( $this->params !== null ) {
+			return;
+		}
+
 		$params = $this->getActualParameters();
 		$this->params = $params;
 

--- a/formats/filtered/src/View/ListView.php
+++ b/formats/filtered/src/View/ListView.php
@@ -33,6 +33,7 @@ class ListView extends View {
 	private $mNamedArgs;
 	private $mShowHeaders;
 	private $mUserParam;
+	private $mSep;
 
 	/** @var array|null */
 	private $params;
@@ -58,6 +59,7 @@ class ListView extends View {
 		$this->mUserParam = $params['list view userparam'];
 
 		$this->mShowHeaders = $params['headers'];
+		$this->mSep = $params['sep'];
 	}
 
 	public function getJsConfig() {
@@ -85,7 +87,7 @@ class ListView extends View {
 			$rowend = "</li>\n";
 
 			// ***diversify from the sep below if necessary
-			$listsep = $this->params['sep'];
+			$listsep = $this->mSep;
 		} else {
 			// "list" format
 			$header = '';
@@ -94,7 +96,7 @@ class ListView extends View {
 			$rowend = "</div>\n";
 
 			// ***diversify from the sep above if necessary
-			$listsep = $this->params['sep'];
+			$listsep = $this->mSep;
 		}
 
 		// Initialise more values


### PR DESCRIPTION
Both `getJsConfig()` and `getResultText()` in `ListView` called `handleParameters()` independently, causing all parameters to be read and assigned twice per render cycle.

Replace the `/** @var array */` declaration with `/** @var array|null */` and add a null-check guard at the start of `handleParameters()`. The existing `$this->params` property serves as the natural lazy-init sentinel — no extra boolean flag needed.