### PR TITLE
docs(filtered): document why addError() widens visibility to public (F-15)

### DIFF
--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -318,6 +318,12 @@ class Filtered extends ResultPrinter {
 		return $resultAsArray;
 	}
 
+	/**
+	 * Widen visibility from protected to public so that View subclasses can
+	 * call $this->getPrinter()->addError() directly.
+	 *
+	 * @inheritDoc
+	 */
 	public function addError( $errorMessage ): void {
 		parent::addError( $errorMessage );
 	}


### PR DESCRIPTION
The `addError()` override in `Filtered` was present without explanation, making it look like dead code.

Add a docblock explaining that the override exists solely to widen visibility from `protected` (parent `ResultPrinter`) to `public`, so that `View` subclasses can call `$this->getPrinter()->addError()` directly.