### PR TITLE
Replace internal wgMonthNames with mediawiki.language.months in JS

### DIFF
--- a/Resources.php
+++ b/Resources.php
@@ -136,7 +136,10 @@ return [
 			'resources/ext.srf.api.query.js',
 		],
 		'position' => 'top',
-		'dependencies' => 'ext.srf',
+		'dependencies' => [
+			'ext.srf',
+			'mediawiki.language.months',
+		],
 		'group' => 'ext.srf'
 	],
 

--- a/resources/ext.srf.api.results.js
+++ b/resources/ext.srf.api.results.js
@@ -10,7 +10,6 @@
  * @licence GPL-2.0-or-later
  * @author mwjames
  */
-/* global wgMonthNames:true */
 ( function( $, mw, srf ) {
  'use strict';
 
@@ -25,13 +24,10 @@
 		pmDesignator: 'PM'
 	};
 
-	// Map wgMonthNames and create an indexed array
-	var monthNames = [];
-	$.map ( mw.config.get( 'wgMonthNames' ), function( value, key ) {
-		if( value !== '' ){
-			monthNames.push( value );
-		}
-	} );
+	// Zero-indexed array of localised month names in the user interface
+	// language, provided by the mediawiki.language.months module (declared
+	// as a dependency of the ext.srf.api module).
+	var monthNames = mw.language.months.names;
 
 	////////////////////////// PUBLIC METHODS /////////////////////////
 


### PR DESCRIPTION
## What

`resources/ext.srf.api.results.js` read month names from `mw.config.get( 'wgMonthNames' )`. In MediaWiki 1.43 that config variable is internal to MediaWiki core: it lives in `OutputPage`'s "Internal variables for MediaWiki core" block, separate from the supported config variables intended for extensions and gadgets. This sources the month names from the `mediawiki.language.months` ResourceLoader module (`mw.language.months.names`), the supported replacement.

## Changes

* `resources/ext.srf.api.results.js`: read `mw.language.months.names` instead of `mw.config.get( 'wgMonthNames' )`. That array is already zero-indexed, so the loop that stripped the empty leading slot is removed, and the `getDate()` lookup by `Date.getMonth()` is unchanged. The stale `global wgMonthNames` eslint directive is dropped since the variable is no longer referenced.
* `Resources.php`: declare `mediawiki.language.months` as a direct dependency of the `ext.srf.api` module that bundles the file.

## Behavior

`wgMonthNames` is built from the page content language, whereas `mediawiki.language.months` is built from the user interface language. On a monolingual wiki, and wherever a reader's interface language is the content language, output is unchanged. On a multilingual wiki where a reader's interface language differs from the page content language, month names in client-rendered query result dates now follow the interface language.

Mirrors the equivalent change in Semantic MediaWiki (SemanticMediaWiki/SemanticMediaWiki#3851).

Closes #480