### PR TITLE
Fix typo in height property name

### DIFF
--- a/formats/googlecharts/SRF_GooglePie.php
+++ b/formats/googlecharts/SRF_GooglePie.php
@@ -12,7 +12,7 @@ use SMW\Query\ResultPrinters\ResultPrinter;
 class SRFGooglePie extends ResultPrinter {
 
 	protected $m_width = 250;
-	protected $m_heighth = 100;
+	protected $m_height = 100;
 
 	/**
 	 * (non-PHPdoc)


### PR DESCRIPTION
`$m_height`, not `$m_heighth`