### PR TITLE
Enable incoming format for CI/test environments

### DIFF
--- a/__setup_extension__
+++ b/__setup_extension__
@@ -1,8 +1,9 @@
-// Enable googlebar and googlepie formats for CI/test environments.
-// These are disabled by default in DefaultSettings.php because they contact
-// an external URL (chart.apis.google.com) to render charts. They are safe to
+// Enable googlebar, googlepie and incoming formats for CI/test environments.
+// googlebar and googlepie are disabled by default in DefaultSettings.php because they
+// contact an external URL (chart.apis.google.com) to render charts. They are safe to
 // enable here since integration tests only assert against the generated HTML,
 // not against an actual HTTP response from Google.
+// incoming is disabled by default because of its potential impact on performance.
 //
 // We register the formats directly into $smwgResultFormats and $wgAutoloadClasses
 // to bypass the srfgFormats → onExtensionFunction timing dependency.
@@ -10,6 +11,8 @@ $wgExtensionFunctions[] = static function () {
 	$dir = __DIR__ . '/extensions/SemanticResultFormats/formats/googlecharts/';
 	$GLOBALS['wgAutoloadClasses']['SRFGoogleBar'] = $dir . 'SRF_GoogleBar.php';
 	$GLOBALS['wgAutoloadClasses']['SRFGooglePie'] = $dir . 'SRF_GooglePie.php';
+	$GLOBALS['wgAutoloadClasses']['SRFIncoming'] = __DIR__ . '/extensions/SemanticResultFormats/formats/incoming/SRF_Incoming.php';
 	$GLOBALS['smwgResultFormats']['googlebar'] = 'SRFGoogleBar';
 	$GLOBALS['smwgResultFormats']['googlepie'] = 'SRFGooglePie';
+	$GLOBALS['smwgResultFormats']['incoming'] = 'SRFIncoming';
 };

--- a/__setup_extension__
+++ b/__setup_extension__
@@ -8,10 +8,10 @@
 // We register the formats directly into $smwgResultFormats and $wgAutoloadClasses
 // to bypass the srfgFormats → onExtensionFunction timing dependency.
 $wgExtensionFunctions[] = static function () {
-	$dir = __DIR__ . '/extensions/SemanticResultFormats/formats/googlecharts/';
-	$GLOBALS['wgAutoloadClasses']['SRFGoogleBar'] = $dir . 'SRF_GoogleBar.php';
-	$GLOBALS['wgAutoloadClasses']['SRFGooglePie'] = $dir . 'SRF_GooglePie.php';
-	$GLOBALS['wgAutoloadClasses']['SRFIncoming'] = __DIR__ . '/extensions/SemanticResultFormats/formats/incoming/SRF_Incoming.php';
+	$dir = __DIR__ . '/extensions/SemanticResultFormats/formats/';
+	$GLOBALS['wgAutoloadClasses']['SRFGoogleBar'] = $dir . 'googlecharts/SRF_GoogleBar.php';
+	$GLOBALS['wgAutoloadClasses']['SRFGooglePie'] = $dir . 'googlecharts/SRF_GooglePie.php';
+	$GLOBALS['wgAutoloadClasses']['SRFIncoming'] = $dir . 'incoming/SRF_Incoming.php';
 	$GLOBALS['smwgResultFormats']['googlebar'] = 'SRFGoogleBar';
 	$GLOBALS['smwgResultFormats']['googlepie'] = 'SRFGooglePie';
 	$GLOBALS['smwgResultFormats']['incoming'] = 'SRFIncoming';


### PR DESCRIPTION
Kept banging my head against a wall not understanding why integration tests consistently failed for `incoming-01.json`, even after I explicitly enabled it in `$srfgFormats`. Until now, luckily. In order for result formats to be tested that are not enabled by default, they must be enabled in the `__set_extension__` file.

Note. Should the `/tests` folder contain a README file to inform testers of this?