### PR TITLE
Refactor makeVariablesScript to remove nonce parameter

### DIFF
--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -57,11 +57,9 @@ final class SRFUtils {
 	 *
 	 * @param array $data
 	 *
-	 * @param string|null|bool $nonce Unused
-	 *
 	 * @return string|WrappedString HTML
 	 */
-	public static function makeVariablesScript( $data, $nonce = null ) {
+	public static function makeVariablesScript( $data ) {
 		$script = MediaWiki\ResourceLoader\ResourceLoader::makeConfigSetScript( $data );
 
 		return MediaWiki\ResourceLoader\ResourceLoader::makeInlineScript( $script );

--- a/SemanticResultFormats.utils.php
+++ b/SemanticResultFormats.utils.php
@@ -57,17 +57,14 @@ final class SRFUtils {
 	 *
 	 * @param array $data
 	 *
-	 * @param string|null|bool $nonce
+	 * @param string|null|bool $nonce Unused
 	 *
 	 * @return string|WrappedString HTML
 	 */
 	public static function makeVariablesScript( $data, $nonce = null ) {
 		$script = MediaWiki\ResourceLoader\ResourceLoader::makeConfigSetScript( $data );
-		if ( $nonce === null ) {
-			$nonce = RequestContext::getMain()->getOutput()->getCSP()->getNonce();
-		}
 
-		return MediaWiki\ResourceLoader\ResourceLoader::makeInlineScript( $script, $nonce );
+		return MediaWiki\ResourceLoader\ResourceLoader::makeInlineScript( $script );
 	}
 
 }


### PR DESCRIPTION
Removed unused nonce parameter from `makeVariablesScript()` method. It was added with #799 but `ResourceLoader::makeInlineScript()` stopped making use of it in MW 1.41. Because the method is not called anywhere in the code with a value assignment for the `nonce` argument, it should be safe to remove it altogether.

(P.S. I could be wrong, but my assumption is that the next SRF release will not support MW 1.40 or lower)
