### PR TITLE
Rename jqplotseries cursor parameter to chartcursor

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -56,6 +56,7 @@ Released on TBD.
 
 * Raised minimum PHP version from 8.1 to 8.2 to align with `mediawiki-codesniffer` v51 and `minus-x` v2 (by [gesinn.it](https://gesinn.it))
 * Renamed the `array`/`hash` formats' `manysep` parameter to `valuesep` for consistency with the core `list` format; `manysep` remains supported as an alias ([466](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/466)) (by [Professional Wiki](https://professional.wiki))
+* Renamed the `jqplotseries` format's `cursor` parameter to `chartcursor`, since SMW 7.0+ reserves `cursor` for keyset pagination; no alias is possible, so queries left on `cursor=zoom|tooltip` keep erroring ([1078](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078)) (by [Professional Wiki](https://professional.wiki))
 * Added CI for MediaWiki 1.43+, removed MediaWiki 1.39 ([1001](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1001)) (by @paladox)
 * Corrected the output of nine statistical `math` result formats; wikis relying on the previous values will see different results ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
 
@@ -92,7 +93,7 @@ Released on TBD.
 * Fixed the `quartillower`, `quartilupper`, their `.exc` variants and both `interquartilerange` formats interpolating with constant factors instead of the position's fractional part, returning wrong values for most result-set sizes ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
 * Fixed `mode` returning the occurrence count instead of the most frequent value ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
 * Fixed `variance` losing precision for values large relative to their spread, which could make `standarddeviation` return `NAN` ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
-* Fixed `jqplotseries` format showing a "Malformed `cursor=` token" query error on every chart with SMW 7.0+: the format's jqPlot cursor-plugin parameter shadowed the `cursor` query parameter reserved by SMW's keyset pagination, so its default value was rejected as a pagination token. The display parameter is renamed to `chartcursor`; queries explicitly setting `cursor=zoom|tooltip` need to switch to `chartcursor=` ([1078](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078)) (by [Professional Wiki](https://professional.wiki))
+* Fixed `jqplotseries` format showing a "Malformed `cursor=` token" query error on every chart with SMW 7.0+ ([1078](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078)) (by [Professional Wiki](https://professional.wiki))
 * Updated translations (by translatewiki.net community)
 
 ## SRF 5.2.0

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -92,6 +92,7 @@ Released on TBD.
 * Fixed the `quartillower`, `quartilupper`, their `.exc` variants and both `interquartilerange` formats interpolating with constant factors instead of the position's fractional part, returning wrong values for most result-set sizes ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
 * Fixed `mode` returning the occurrence count instead of the most frequent value ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
 * Fixed `variance` losing precision for values large relative to their spread, which could make `standarddeviation` return `NAN` ([1120](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1120)) (by [Professional Wiki](https://professional.wiki))
+* Fixed `jqplotseries` format showing a "Malformed `cursor=` token" query error on every chart with SMW 7.0+: the format's jqPlot cursor-plugin parameter shadowed the `cursor` query parameter reserved by SMW's keyset pagination, so its default value was rejected as a pagination token. The display parameter is renamed to `chartcursor`; queries explicitly setting `cursor=zoom|tooltip` need to switch to `chartcursor=` ([1078](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078)) (by [Professional Wiki](https://professional.wiki))
 * Updated translations (by translatewiki.net community)
 
 ## SRF 5.2.0

--- a/formats/jqplot/SRF_jqPlotSeries.php
+++ b/formats/jqplot/SRF_jqPlotSeries.php
@@ -207,7 +207,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 			'gridview' => $this->params['gridview'],
 			'direction' => $this->params['direction'],
 			'smoothlines' => $this->params['smoothlines'],
-			'cursor' => $this->params['cursor'],
+			'cursor' => $this->params['chartcursor'],
 			'chartlegend' => $this->params['chartlegend'] !== '' ? $this->params['chartlegend'] : 'none',
 			'colorscheme' => $this->params['colorscheme'] !== '' ? $this->params['colorscheme'] : null,
 			'pointlabels' => $this->params['datalabels'] === 'none' ? false : $this->params['datalabels'],
@@ -289,7 +289,7 @@ class SRFjqPlotSeries extends ResultPrinter {
 		}
 
 		// Cursor plugin
-		if ( in_array( $this->params['cursor'], [ 'zoom', 'tooltip' ] ) ) {
+		if ( in_array( $this->params['chartcursor'], [ 'zoom', 'tooltip' ] ) ) {
 			SMWOutputs::requireResource( 'ext.srf.jqplot.cursor' );
 		}
 
@@ -414,7 +414,9 @@ class SRFjqPlotSeries extends ResultPrinter {
 			'values' => [ 'none', 'exp', 'linear' ],
 		];
 
-		$params['cursor'] = [
+		// `cursor` is reserved by SMW >= 7.0 for keyset pagination tokens
+		// and must not be used as a format parameter name
+		$params['chartcursor'] = [
 			'message' => 'srf-paramdesc-chartcursor',
 			'default' => 'none',
 			'values' => [ 'none', 'zoom', 'tooltip' ],

--- a/tests/node-qunit/ext.srf.jqplot.chart.test.js
+++ b/tests/node-qunit/ext.srf.jqplot.chart.test.js
@@ -309,8 +309,11 @@ QUnit.module( 'ext.srf.jqplot.chart.bar', () => {
 		QUnit.test( 'cursor plugin stays hidden for non-numeric first columns', ( assert ) => {
 			const config = plot( makeChartData( { parameters: { cursor: 'zoom' } } ) );
 
+			// Only `show` is asserted: it is what gates the plugin. The
+			// remaining flags track the parameter regardless of column type,
+			// which jqPlot ignores while `show` is false — pinning them here
+			// would fail a legitimate future cleanup that gates all four.
 			assert.false( config.cursor.show, 'zooming needs a numeric or date first column' );
-			assert.true( config.cursor.zoom, 'the zoom flag itself follows the parameter' );
 		} );
 
 		QUnit.test( 'bar renderer and vertical axes are configured', ( assert ) => {

--- a/tests/node-qunit/ext.srf.jqplot.chart.test.js
+++ b/tests/node-qunit/ext.srf.jqplot.chart.test.js
@@ -1,0 +1,326 @@
+'use strict';
+
+const path = require( 'path' );
+const sinon = require( 'sinon' );
+
+// ext.srf.jqplot.chart.js defines the container plugin plus srfjqPlotTheme;
+// ext.srf.jqplot.chart.bar.js consumes them, matching the real ResourceLoader
+// bundle order declared for "ext.srf.jqplot.bar" in Resources.php. The vendored
+// jqPlot library itself is canvas-bound and stays out of jsdom; the plotting
+// call boundary ($.jqplot) is stubbed per test instead.
+require( path.resolve( __dirname, '../../formats/jqplot/resources/ext.srf.jqplot.chart.js' ) );
+require( path.resolve( __dirname, '../../formats/jqplot/resources/ext.srf.jqplot.chart.bar.js' ) );
+
+/**
+ * Chart data as emitted by SRFjqPlotSeries::getFormatSettings() /
+ * SRFjqPlot::getCommonParams() on the PHP side, reduced to the fields the
+ * client-side modules read.
+ *
+ * @param {Object} overrides own properties replace the defaults; a nested
+ *  `parameters` object is merged key-by-key
+ * @return {Object}
+ */
+function makeChartData( overrides ) {
+	overrides = overrides || {};
+
+	const data = Object.assign( {
+		data: [ [ [ 'Page A', 10 ], [ 'Page B', 20 ] ] ],
+		series: [ { label: 'Series 1' } ],
+		ticks: [ 0, 10, 20 ],
+		total: 30,
+		fcolumntypeid: '_wpg',
+		mode: 'series',
+		renderer: 'bar',
+		legendLabels: [ 'Series 1' ],
+		sask: ''
+	}, overrides );
+
+	data.parameters = Object.assign( {
+		numbersaxislabel: '',
+		labelaxislabel: '',
+		charttitle: '',
+		charttext: '',
+		infotext: '',
+		theme: null,
+		valueformat: '%d',
+		ticklabels: true,
+		highlighter: false,
+		autoscale: false,
+		gridview: 'none',
+		direction: 'vertical',
+		smoothlines: false,
+		cursor: 'none',
+		chartlegend: 'none',
+		colorscheme: null,
+		pointlabels: false,
+		datalabels: 'none',
+		stackseries: false,
+		grid: null,
+		seriescolors: [ '#ddd' ],
+		hideZeroes: false
+	}, overrides.parameters );
+
+	return data;
+}
+
+/**
+ * Minimal stand-in for the vendored jqPlot library: a callable spy carrying
+ * the renderer constructors and config object the bar module dereferences.
+ *
+ * @return {Function} the spy installed as $.jqplot
+ */
+function stubJqplot() {
+	const jqplot = sinon.spy( () => ( {} ) );
+
+	[
+		'CanvasAxisLabelRenderer', 'CanvasAxisTickRenderer', 'LinearAxisRenderer',
+		'CategoryAxisRenderer', 'BarRenderer', 'LineRenderer', 'EnhancedLegendRenderer'
+	].forEach( ( renderer ) => {
+		jqplot[ renderer ] = function () {};
+	} );
+	jqplot.config = {};
+
+	$.jqplot = jqplot;
+	return jqplot;
+}
+
+QUnit.module( 'ext.srf.jqplot.chart', ( hooks ) => {
+
+	let barSpy, pieSpy, bubbleSpy;
+
+	hooks.beforeEach( () => {
+		barSpy = sinon.replace( $.fn, 'srfjqPlotBarChartData', sinon.fake() );
+		// The pie/bubble modules are not loaded here; provide their plugin
+		// entry points so the dispatch can be observed
+		pieSpy = $.fn.srfjqPlotPieChart = sinon.fake();
+		bubbleSpy = $.fn.srfjqPlotBubbleChartData = sinon.fake();
+	} );
+
+	hooks.afterEach( () => {
+		delete $.fn.srfjqPlotPieChart;
+		delete $.fn.srfjqPlotBubbleChartData;
+	} );
+
+	/**
+	 * @param {Object} data chart data, stored under the container id "chart-1"
+	 *  as srfjqPlotChartContainer() reads it back via mw.config
+	 * @return {jQuery} the chart wrapper attached to the document
+	 */
+	function createChart( data ) {
+		mw.config.set( 'chart-1', data );
+
+		return $(
+			'<div class="srf-jqplot bar">' +
+			'<div class="container" id="chart-1" style="display:none"><canvas></canvas></div>' +
+			'</div>'
+		).appendTo( document.body );
+	}
+
+	QUnit.test( 'bar renderer data is dispatched to the bar plugin', ( assert ) => {
+		const chart = createChart( makeChartData() );
+
+		chart.srfjqPlotChartContainer();
+
+		assert.strictEqual( barSpy.callCount, 1, 'srfjqPlotBarChartData() was called' );
+		assert.strictEqual( barSpy.firstCall.args[ 0 ].id, 'chart-1-plot', 'the plotting area id was passed' );
+		assert.strictEqual( barSpy.firstCall.args[ 0 ].data.renderer, 'bar', 'the parsed chart data was passed' );
+		assert.strictEqual( pieSpy.callCount, 0, 'the pie plugin was not involved' );
+		assert.strictEqual( bubbleSpy.callCount, 0, 'the bubble plugin was not involved' );
+	} );
+
+	QUnit.test( 'JSON string data is parsed before dispatch', ( assert ) => {
+		const chart = createChart( JSON.stringify( makeChartData( { renderer: 'line' } ) ) );
+
+		chart.srfjqPlotChartContainer();
+
+		assert.strictEqual( barSpy.firstCall.args[ 0 ].data.renderer, 'line', 'the JSON string was parsed into an object' );
+	} );
+
+	QUnit.test( 'pie and donut renderers are dispatched to the pie plugin', ( assert ) => {
+		createChart( makeChartData( { renderer: 'pie' } ) ).srfjqPlotChartContainer();
+
+		assert.strictEqual( pieSpy.callCount, 1, 'srfjqPlotPieChart() was called for renderer "pie"' );
+
+		createChart( makeChartData( { renderer: 'donut' } ) ).srfjqPlotChartContainer();
+
+		assert.strictEqual( pieSpy.callCount, 2, 'srfjqPlotPieChart() was called for renderer "donut"' );
+		assert.strictEqual( barSpy.callCount, 0, 'the bar plugin was not involved' );
+	} );
+
+	QUnit.test( 'bubble renderer is dispatched to the bubble plugin', ( assert ) => {
+		createChart( makeChartData( { renderer: 'bubble' } ) ).srfjqPlotChartContainer();
+
+		assert.strictEqual( bubbleSpy.callCount, 1, 'srfjqPlotBubbleChartData() was called' );
+	} );
+
+	QUnit.test( 'container is released for display with a plotting area', ( assert ) => {
+		const chart = createChart( makeChartData() );
+
+		chart.srfjqPlotChartContainer();
+
+		const container = chart.find( '.container' );
+		assert.notStrictEqual( container.css( 'display' ), 'none', 'the container was shown' );
+		assert.strictEqual( container.find( 'canvas' ).length, 0, 'stale canvas elements were removed' );
+		assert.strictEqual( container.find( '#chart-1-plot.srf-jqplot-plot.bar' ).length, 1, 'the plotting area div was created' );
+	} );
+
+	QUnit.test( 'chart text is prepended when the charttext parameter is set', ( assert ) => {
+		const chart = createChart( makeChartData( { parameters: { charttext: 'About this chart' } } ) );
+
+		chart.srfjqPlotChartContainer();
+
+		const text = chart.find( '.srf-jqplot-chart-text' );
+		assert.strictEqual( text.length, 1, 'the chart text element was created' );
+		assert.strictEqual( text.text(), 'About this chart', 'the chart text was inserted' );
+		assert.true( text.hasClass( 'bar' ), 'the renderer class was added to the text element' );
+	} );
+} );
+
+QUnit.module( 'ext.srf.jqplot.chart.bar', () => {
+
+	QUnit.module( 'srfjqPlotBarChartData()', ( hooks ) => {
+
+		let plotSpy;
+
+		hooks.beforeEach( () => {
+			plotSpy = sinon.replace( $.fn, 'srfjqPlotBarChart', sinon.fake() );
+		} );
+
+		/**
+		 * @param {Object} data
+		 * @return {Object} the options srfjqPlotBarChart() was called with
+		 */
+		function transform( data ) {
+			$( '<div>' ).srfjqPlotBarChartData( { id: 'plot-1', data: data, height: 400, width: 600, chart: $( '<div>' ) } );
+
+			return plotSpy.firstCall.args[ 0 ];
+		}
+
+		QUnit.test( 'vertical category series keeps plain value arrays', ( assert ) => {
+			const options = transform( makeChartData() );
+
+			assert.deepEqual( options.barData, [ [ 10, 20 ] ], 'values were extracted per series' );
+			assert.deepEqual( options.labels, [ 'Page A', 'Page B' ], 'first-column labels were collected separately' );
+		} );
+
+		QUnit.test( 'horizontal direction produces [value, position] pairs', ( assert ) => {
+			const options = transform( makeChartData( { parameters: { direction: 'horizontal' } } ) );
+
+			assert.deepEqual( options.barData, [ [ [ 10, 1 ], [ 20, 2 ] ] ], 'values were paired with their 1-based position' );
+		} );
+
+		QUnit.test( 'numeric first column keeps [x, y] pairs', ( assert ) => {
+			const options = transform( makeChartData( {
+				data: [ [ [ 1, 10 ], [ 2, 20 ] ] ],
+				fcolumntypeid: '_num'
+			} ) );
+
+			assert.deepEqual( options.barData, [ [ [ 1, 10 ], [ 2, 20 ] ] ], 'numeric x-values were preserved' );
+		} );
+
+		QUnit.test( 'stacked series of unequal length bail out with an error', ( assert ) => {
+			mw.msg = () => 'unequal series length';
+
+			const context = $( '<div>' );
+			context.srfjqPlotBarChartData( {
+				id: 'plot-1',
+				data: makeChartData( {
+					data: [ [ [ 'Page A', 10 ], [ 'Page B', 20 ] ], [ [ 'Page A', 30 ] ] ],
+					parameters: { stackseries: true }
+				} ),
+				height: 400,
+				width: 600,
+				chart: $( '<div>' )
+			} );
+
+			assert.strictEqual( plotSpy.callCount, 0, 'no plotting was attempted' );
+			assert.strictEqual( context.text(), 'unequal series length', 'the error message was shown instead' );
+		} );
+	} );
+
+	QUnit.module( 'srfjqPlotBarChart()', ( hooks ) => {
+
+		let themeSpy;
+
+		hooks.beforeEach( () => {
+			themeSpy = sinon.replace( $.fn, 'srfjqPlotTheme', sinon.fake() );
+		} );
+
+		hooks.afterEach( () => {
+			delete $.jqplot;
+		} );
+
+		/**
+		 * @param {Object} data
+		 * @return {Object} the configuration passed to $.jqplot()
+		 */
+		function plot( data ) {
+			const jqplot = stubJqplot();
+
+			$( '<div>' ).srfjqPlotBarChart( {
+				id: 'plot-1',
+				data: data,
+				barData: [ [ 10, 20 ] ],
+				labels: data.fcolumntypeid === '_num' ? [ 1, 2 ] : [ 'Page A', 'Page B' ],
+				height: 400,
+				width: 600,
+				chart: $( '<div>' )
+			} );
+
+			return jqplot.firstCall.args[ 2 ];
+		}
+
+		QUnit.test( 'chartcursor zoom enables the cursor plugin in zoom mode', ( assert ) => {
+			const config = plot( makeChartData( {
+				fcolumntypeid: '_num',
+				parameters: { cursor: 'zoom' }
+			} ) );
+
+			assert.deepEqual(
+				config.cursor,
+				{ show: true, zoom: true, looseZoom: true, showTooltip: false },
+				'the cursor plugin was configured for zooming'
+			);
+		} );
+
+		QUnit.test( 'chartcursor tooltip enables the cursor plugin in tooltip mode', ( assert ) => {
+			const config = plot( makeChartData( {
+				fcolumntypeid: '_num',
+				parameters: { cursor: 'tooltip' }
+			} ) );
+
+			assert.deepEqual(
+				config.cursor,
+				{ show: true, zoom: false, looseZoom: false, showTooltip: true },
+				'the cursor plugin was configured for tooltips'
+			);
+		} );
+
+		QUnit.test( 'default chartcursor none keeps the cursor plugin off', ( assert ) => {
+			const config = plot( makeChartData( { fcolumntypeid: '_num' } ) );
+
+			assert.deepEqual(
+				config.cursor,
+				{ show: false, zoom: false, looseZoom: false, showTooltip: false },
+				'the cursor plugin stayed off'
+			);
+		} );
+
+		QUnit.test( 'cursor plugin stays hidden for non-numeric first columns', ( assert ) => {
+			const config = plot( makeChartData( { parameters: { cursor: 'zoom' } } ) );
+
+			assert.false( config.cursor.show, 'zooming needs a numeric or date first column' );
+			assert.true( config.cursor.zoom, 'the zoom flag itself follows the parameter' );
+		} );
+
+		QUnit.test( 'bar renderer and vertical axes are configured', ( assert ) => {
+			const config = plot( makeChartData() );
+
+			assert.strictEqual( config.seriesDefaults.renderer, $.jqplot.BarRenderer, 'bars use the bar renderer' );
+			assert.deepEqual( config.axes.xaxis.ticks, [ 'Page A', 'Page B' ], 'the x-axis carries the category labels' );
+			assert.deepEqual( config.axes.yaxis.ticks, [ 0, 10, 20 ], 'the y-axis carries the number ticks' );
+			assert.strictEqual( config.legend, null, 'chartlegend "none" disables the legend' );
+			assert.strictEqual( themeSpy.callCount, 1, 'theming was applied to the plot' );
+		} );
+	} );
+} );

--- a/tests/node-qunit/setup.js
+++ b/tests/node-qunit/setup.js
@@ -21,6 +21,10 @@ function createDom() {
 	// the bare (unprefixed) confirm()/window.open() globals directly.
 	global.confirm = window.confirm;
 	global.$ = global.jQuery = require( 'jquery' );
+	// In a real browser jQuery also hangs off the window object; the jqplot
+	// modules (ext.srf.jqplot.chart.bar/pie/bubble.js) pass window.jQuery into
+	// their IIFEs explicitly.
+	window.jQuery = window.$ = global.jQuery;
 	// MediaWiki core's jquery.client RL module (browser detection), not vendored
 	// here; srf.formats.eventcalendar reads profile.name/.versionNumber.
 	$.client = {

--- a/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `format=jqplotseries` html output (#1018)",
+	"description": "Test `format=jqplotseries` html output (#1018, #1078)",
 	"setup": [
 		{
 			"page": "Has SRFJqplot01 value",
@@ -17,16 +17,36 @@
 		{
 			"page": "Test/Jqplot01/Q.1",
 			"contents": "{{#ask: [[Category:SRFJqplot01]] |?Has SRFJqplot01 value |format=jqplotseries }}"
+		},
+		{
+			"page": "Test/Jqplot01/Q.2",
+			"contents": "{{#ask: [[Category:SRFJqplot01]] |?Has SRFJqplot01 value |format=jqplotseries |charttype=line |chartcursor=zoom }}"
 		}
 	],
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0 results with numeric data – chart container rendered",
+			"about": "#0 results with numeric data – chart container rendered, no reserved-cursor query error (#1078)",
 			"subject": "Test/Jqplot01/Q.1",
 			"assert-output": {
 				"to-contain": [
 					"srf-jqplot"
+				],
+				"not-contain": [
+					"Malformed"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 explicit `chartcursor=zoom` – chart container rendered, no reserved-cursor query error (#1078)",
+			"subject": "Test/Jqplot01/Q.2",
+			"assert-output": {
+				"to-contain": [
+					"srf-jqplot"
+				],
+				"not-contain": [
+					"Malformed"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/jqplotseries-01.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"type": "parser",
-			"about": "#1 explicit `chartcursor=zoom` – chart container rendered, no reserved-cursor query error (#1078)",
+			"about": "#1 explicit `chartcursor=zoom` is not routed into keyset pagination (#1078); SMW discards parameter-processing errors, so this cannot detect a misspelled parameter name – `jqPlotSeriesTest` covers registration",
 			"subject": "Test/Jqplot01/Q.2",
 			"assert-output": {
 				"to-contain": [

--- a/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
+++ b/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
@@ -2,7 +2,9 @@
 
 namespace SRF\Tests\Unit\Formats;
 
+use ReflectionClass;
 use SMW\Tests\QueryPrinterRegistryTestCase;
+use SRF\Tests\ResultPrinterReflector;
 
 /**
  * Tests for the SRF\jqPlotSeries class.
@@ -48,7 +50,7 @@ class jqPlotSeriesTest extends QueryPrinterRegistryTestCase {
 	 * @covers \SRFjqPlotSeries::getParamDefinitions
 	 */
 	public function testDefinesChartCursorParameter() {
-		$definitions = $this->newPrinter()->getParamDefinitions( [] );
+		$definitions = $this->newInstance( 'jqplotseries', true )->getParamDefinitions( [] );
 
 		$this->assertArrayHasKey( 'chartcursor', $definitions );
 		$this->assertSame( 'none', $definitions['chartcursor']['default'] );
@@ -56,22 +58,111 @@ class jqPlotSeriesTest extends QueryPrinterRegistryTestCase {
 	}
 
 	/**
-	 * `cursor` is reserved by SMW >= 7.0 for keyset pagination tokens; a
-	 * format parameter of that name is fed into the pagination machinery
-	 * and rejected as a malformed token.
+	 * `cursor` is reserved by SMW >= 7.0 for keyset pagination tokens, and is
+	 * registered globally by `SMW\Query\Processor\DefaultParamDefinition` with
+	 * an empty default. A format that adds — or overwrites — a definition of
+	 * that name feeds its own default into the pagination machinery, where it
+	 * is rejected as a malformed token.
+	 *
+	 * Passing SMW's own definition in asserts the stronger property: the format
+	 * must leave an inherited `cursor` untouched, not merely refrain from
+	 * adding one.
 	 *
 	 * @see https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078
 	 *
 	 * @covers \SRFjqPlotSeries::getParamDefinitions
 	 */
 	public function testDoesNotDefineReservedCursorParameter() {
-		$definitions = $this->newPrinter()->getParamDefinitions( [] );
+		$reserved = [ 'cursor' => [ 'default' => '' ] ];
 
-		$this->assertArrayNotHasKey( 'cursor', $definitions );
+		$definitions = $this->newInstance( 'jqplotseries', true )->getParamDefinitions( $reserved );
+
+		$this->assertSame( '', $definitions['cursor']['default'] );
 	}
 
-	private function newPrinter(): \SRFjqPlotSeries {
-		return new \SRFjqPlotSeries( 'jqplotseries' );
+	/**
+	 * The parameter is `chartcursor` on the wiki side, but the chart data JSON
+	 * handed to the client keeps the historical `cursor` key, which
+	 * `ext.srf.jqplot.chart.bar.js` reads. Renaming one without the other
+	 * silently disables the jqPlot cursor plugin.
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078
+	 *
+	 * @covers \SRFjqPlotSeries::getFormatSettings
+	 */
+	public function testChartCursorIsEmittedAsCursorInChartData() {
+		$settings = $this->newFormatSettings( [ 'chartcursor' => 'zoom' ] );
+
+		$this->assertSame( 'zoom', $settings['parameters']['cursor'] );
+		$this->assertArrayNotHasKey( 'chartcursor', $settings['parameters'] );
+	}
+
+	/**
+	 * @covers \SRFjqPlotSeries::getFormatSettings
+	 */
+	public function testChartCursorDefaultIsEmittedAsCursorInChartData() {
+		$settings = $this->newFormatSettings();
+
+		$this->assertSame( 'none', $settings['parameters']['cursor'] );
+	}
+
+	/**
+	 * Invokes the private `getFormatSettings()` against a minimal single-series
+	 * data set, with the printer's parameters set to the format's own defaults
+	 * plus any overrides.
+	 *
+	 * @param array $params overrides for the default parameter values
+	 *
+	 * @return array the chart data as handed to the client
+	 */
+	private function newFormatSettings( array $params = [] ): array {
+		$instance = $this->newInstance( 'jqplotseries', true );
+
+		( new ResultPrinterReflector() )->addParameters(
+			$instance,
+			array_merge( [
+				'group' => 'subject',
+				'grouplabel' => 'subject',
+				'charttype' => 'bar',
+				'chartcolor' => '',
+				'chartcursor' => 'none',
+				'chartlegend' => '',
+				'charttitle' => '',
+				'charttext' => '',
+				'infotext' => '',
+				'colorscheme' => '',
+				'datalabels' => 'none',
+				'direction' => 'vertical',
+				'gridview' => 'none',
+				'hidezeroes' => false,
+				'highlighter' => false,
+				'labelaxislabel' => '',
+				'numbersaxislabel' => '',
+				'smoothlines' => false,
+				'stackseries' => false,
+				'theme' => '',
+				'ticklabels' => true,
+				'trendline' => 'none',
+				'valueformat' => '%d',
+			], $params )
+		);
+
+		$data = [
+			'subject' => [
+				'Page A' => [
+					[ 'subject' => 'Page A', 'value' => 10, 'property' => 'Has value' ],
+				],
+			],
+			'numbersticks' => [ 0, 10 ],
+			'total' => 10,
+			'fcolumntypeid' => '_num',
+		];
+
+		$reflector = new ReflectionClass( $instance );
+		$method = $reflector->getMethod( 'getFormatSettings' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $instance, $data, [ 'sask' => '' ] );
 	}
 
 }

--- a/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
+++ b/tests/phpunit/Unit/Formats/jqPlotSeriesTest.php
@@ -44,4 +44,34 @@ class jqPlotSeriesTest extends QueryPrinterRegistryTestCase {
 		return '\SRFjqPlotSeries';
 	}
 
+	/**
+	 * @covers \SRFjqPlotSeries::getParamDefinitions
+	 */
+	public function testDefinesChartCursorParameter() {
+		$definitions = $this->newPrinter()->getParamDefinitions( [] );
+
+		$this->assertArrayHasKey( 'chartcursor', $definitions );
+		$this->assertSame( 'none', $definitions['chartcursor']['default'] );
+		$this->assertSame( [ 'none', 'zoom', 'tooltip' ], $definitions['chartcursor']['values'] );
+	}
+
+	/**
+	 * `cursor` is reserved by SMW >= 7.0 for keyset pagination tokens; a
+	 * format parameter of that name is fed into the pagination machinery
+	 * and rejected as a malformed token.
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078
+	 *
+	 * @covers \SRFjqPlotSeries::getParamDefinitions
+	 */
+	public function testDoesNotDefineReservedCursorParameter() {
+		$definitions = $this->newPrinter()->getParamDefinitions( [] );
+
+		$this->assertArrayNotHasKey( 'cursor', $definitions );
+	}
+
+	private function newPrinter(): \SRFjqPlotSeries {
+		return new \SRFjqPlotSeries( 'jqplotseries' );
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1078

Since SMW 7.0 the query processor reads a reserved `cursor` parameter as a keyset pagination token. The jqplotseries format defined a display parameter of the same name for the jqPlot cursor plugin (default `none`), so every jqplotseries query passed `cursor=none` into the pagination machinery, which rejects it with a "Malformed `cursor=` token" query error shown next to the chart.

The parameter is renamed to `chartcursor`, matching its existing i18n message key `srf-paramdesc-chartcursor`. The JavaScript-facing key in the chart data JSON stays `cursor`, so the frontend is unchanged. A back-compat alias is not possible because the old name itself conflicts with the reserved query parameter.

Migration: queries explicitly setting `cursor=zoom` or `cursor=tooltip` need to switch to `chartcursor=`.

Part of: https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1054

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; one-line ask from @kghbln pointing at the issue; no revisions; diff not yet human-reviewed; local PHPUnit unavailable — JSON validated, root cause verified against SMW 7.0.0 source, tests await CI.</sub>
