### PR TITLE
Update sfs_version to 5.0.0 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - mediawiki_version: '1.43'
             smw_version: 7.0.0
             pf_version: 5.9
-            sfs_version: 4.0.0-beta
+            sfs_version: 5.0.0
             php_version: 8.3
             mm_version: 6.0.2
             database_type: mysql


### PR DESCRIPTION
Released two months ago: https://github.com/SemanticMediaWiki/SemanticFormsSelect/releases/tag/5.0.0