### PR TITLE
Rename array format manysep parameter to valuesep

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -55,6 +55,7 @@ Released on TBD.
 ### Compatibility Changes
 
 * Raised minimum PHP version from 8.1 to 8.2 to align with `mediawiki-codesniffer` v51 and `minus-x` v2 (by [gesinn.it](https://gesinn.it))
+* Renamed the `array`/`hash` formats' `manysep` parameter to `valuesep` for consistency with the core `list` format; `manysep` remains supported as an alias ([466](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/466)) (by [Professional Wiki](https://professional.wiki))
 * Added CI for MediaWiki 1.43+, removed MediaWiki 1.39 ([1001](https://github.com/SemanticMediaWiki/SemanticResultFormats/pull/1001)) (by @paladox)
 
 ### New Features and Enhancements

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -185,7 +185,7 @@
 	"srf_paramdesc_hidegaps": "{{doc-paramdesc|hidegaps}}",
 	"srf_paramdesc_arrayname": "{{doc-paramdesc|name}}",
 	"srf_paramdesc_propsep": "{{doc-paramdesc|propsep}}",
-	"srf_paramdesc_manysep": "{{doc-paramdesc|manysep}}",
+	"srf_paramdesc_manysep": "{{doc-paramdesc|valuesep}}",
 	"srf_paramdesc_recordsep": "{{doc-paramdesc|recordsep}}",
 	"srf_paramdesc_headersep": "{{doc-smwformat|headersep}}\n{{doc-important|Do not translate the parameter name \"headers\" and its possible values \"show\" or \"plain\".}}",
 	"srf_printername_hash": "{{doc-smwformat|hash}}\n{{Identical|Hash}}",

--- a/src/ArrayFormat/ArrayPrinter.php
+++ b/src/ArrayFormat/ArrayPrinter.php
@@ -293,7 +293,7 @@ class ArrayPrinter extends ResultPrinter {
 	protected function applyArrayParameters( array $params ): void {
 		$this->mSep = $params['sep'];
 		$this->mPropSep = $params['propsep'];
-		$this->mManySep = $params['manysep'];
+		$this->mManySep = $params['valuesep'];
 		$this->mRecordSep = $params['recordsep'];
 		$this->mHeaderSep = $params['headersep'];
 
@@ -370,9 +370,13 @@ class ArrayPrinter extends ResultPrinter {
 			'default' => $this->initializeCfgValue( $srfgArrayPropSep, 'propsep' ),
 		];
 
-		$params['manysep'] = [
+		// Renamed from `manysep` for consistency with the core `list`
+		// format; the old name stays usable as an alias. The message and
+		// the fallback cache key keep the historical name.
+		$params['valuesep'] = [
 			'message' => 'srf_paramdesc_manysep',
 			'default' => $this->initializeCfgValue( $srfgArrayManySep, 'manysep' ),
+			'aliases' => [ 'manysep' ],
 		];
 
 		$params['recordsep'] = [

--- a/src/ArrayFormat/ArrayPrinter.php
+++ b/src/ArrayFormat/ArrayPrinter.php
@@ -371,8 +371,9 @@ class ArrayPrinter extends ResultPrinter {
 		];
 
 		// Renamed from `manysep` for consistency with the core `list`
-		// format; the old name stays usable as an alias. The message and
-		// the fallback cache key keep the historical name.
+		// format; the old name stays usable as an alias. The message key
+		// and the fallback cache key both keep the historical name, so no
+		// wiki-side configuration changes are needed.
 		$params['valuesep'] = [
 			'message' => 'srf_paramdesc_manysep',
 			'default' => $this->initializeCfgValue( $srfgArrayManySep, 'manysep' ),

--- a/tests/phpunit/Unit/Formats/SRFArrayTest.php
+++ b/tests/phpunit/Unit/Formats/SRFArrayTest.php
@@ -459,4 +459,98 @@ class SRFArrayTest extends TestCase {
 		$this->assertStringContainsString( 'PropValue', $result );
 	}
 
+	/**
+	 * Returns a ResultArray mock delivering one DataValue per given text.
+	 */
+	private function newField( array $texts ) {
+		$values = [];
+		foreach ( $texts as $text ) {
+			$value = $this->getMockBuilder( \SMWDataValue::class )
+				->disableOriginalConstructor()
+				->getMock();
+			$value->method( 'getShortWikiText' )->willReturn( $text );
+			$values[] = $value;
+		}
+
+		$field = $this->createMock( ResultArray::class );
+		$field->method( 'getContent' )->willReturn( $values );
+		$field->method( 'getNextDataValue' )
+			->willReturnOnConsecutiveCalls( ...array_merge( $values, [ false ] ) );
+
+		return $field;
+	}
+
+	public function testGetResultTextJoinsValuesPropertiesAndPagesWithConfiguredSeparators(): void {
+		$res = $this->createMock( QueryResult::class );
+		$res->method( 'getNext' )->willReturnOnConsecutiveCalls(
+			[
+				$this->newField( [ 'PageA' ] ),
+				$this->newField( [ 'V1', 'V2' ] ),
+			],
+			[
+				$this->newField( [ 'PageB' ] ),
+				$this->newField( [ 'V3' ] ),
+			],
+			false
+		);
+
+		$instance = $this->newInstance( [
+			'mShowPageTitles' => true,
+			'mShowHeaders'    => SMW_HEADERS_HIDE,
+			'mMainLabelHack'  => false,
+		] );
+
+		$result = $instance->getResultText( $res, SMW_OUTPUT_WIKI );
+		$this->assertSame( 'PageA<PROP>V1<MANY>V2, PageB<PROP>V3', $result );
+	}
+
+	public function testGetResultTextRecordFieldsAreRecordSeparated(): void {
+		$record = $this->createMock( \SMWRecordValue::class );
+		$record->method( 'getDataItems' )->willReturn( [ null, null ] );
+
+		$field = $this->createMock( ResultArray::class );
+		$field->method( 'getContent' )->willReturn( [ $record ] );
+		$field->method( 'getNextDataValue' )->willReturnOnConsecutiveCalls( $record, false );
+
+		$res = $this->createMock( QueryResult::class );
+		$res->method( 'getNext' )->willReturnOnConsecutiveCalls( [ $field ], false );
+
+		$instance = $this->newInstance( [
+			'mShowHeaders'    => SMW_HEADERS_HIDE,
+			'mMainLabelHack'  => true,
+			'mHideRecordGaps' => false,
+		] );
+
+		$this->assertSame( '<RCRD>', $instance->getResultText( $res, SMW_OUTPUT_WIKI ) );
+	}
+
+	public function testDeliverSingleValueTrimsAndDecodesCharacterReferences(): void {
+		$value = $this->getMockBuilder( \SMWDataValue::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$value->method( 'getShortWikiText' )->willReturn( '  A&amp;B ' );
+
+		$instance = new class( 'array' ) extends ArrayPrinter {
+			public function deliverSingleValuePublic( $value ) {
+				return parent::deliverSingleValue( $value );
+			}
+		};
+
+		$this->assertSame( 'A&B', $instance->deliverSingleValuePublic( $value ) );
+	}
+
+	public function testCreateArrayReturnsFalseWhenNoArraysExtensionInstalled(): void {
+		if ( class_exists( 'ExtArrays' ) ) {
+			$this->markTestSkipped( 'Arrays extension is installed' );
+		}
+
+		$instance = new class( 'array' ) extends ArrayPrinter {
+			public function createArrayPublic( $array ) {
+				return parent::createArray( $array );
+			}
+		};
+
+		$this->assertFalse( $instance->createArrayPublic( [ 'a' ] ) );
+	}
+
 }

--- a/tests/phpunit/Unit/Formats/SRFArrayTest.php
+++ b/tests/phpunit/Unit/Formats/SRFArrayTest.php
@@ -126,7 +126,7 @@ class SRFArrayTest extends TestCase {
 		return array_merge( [
 			'sep'       => ', ',
 			'propsep'   => '<PROP>',
-			'manysep'   => '<MANY>',
+			'valuesep'  => '<MANY>',
 			'recordsep' => '<RCRD>',
 			'headersep' => ': ',
 			'name'      => false,
@@ -255,7 +255,7 @@ class SRFArrayTest extends TestCase {
 		$instance->applyArrayParameters( $this->defaultParams( [
 			'sep'       => '|',
 			'propsep'   => '::',
-			'manysep'   => ';;',
+			'valuesep'  => ';;',
 			'recordsep' => ',,',
 			'headersep' => '=',
 		] ) );
@@ -264,6 +264,22 @@ class SRFArrayTest extends TestCase {
 		$this->assertSame( ';;', $instance->get( 'mManySep' ) );
 		$this->assertSame( ',,', $instance->get( 'mRecordSep' ) );
 		$this->assertSame( '=', $instance->get( 'mHeaderSep' ) );
+	}
+
+	public function testValueSepParameterKeepsManySepAlias(): void {
+		$stub = new class {
+			public function setDefault( $value ) {
+			}
+		};
+		$definitions = $this->newInstance()->getParamDefinitions( [
+			'limit'   => clone $stub,
+			'link'    => clone $stub,
+			'headers' => clone $stub,
+		] );
+
+		$this->assertArrayHasKey( 'valuesep', $definitions );
+		$this->assertSame( [ 'manysep' ], $definitions['valuesep']['aliases'] );
+		$this->assertArrayNotHasKey( 'manysep', $definitions );
 	}
 
 	public function testApplyArrayParametersNameFalseDoesNotSetArrayName(): void {

--- a/tests/phpunit/Unit/Formats/SRFHashTest.php
+++ b/tests/phpunit/Unit/Formats/SRFHashTest.php
@@ -107,7 +107,7 @@ class SRFHashTest extends TestCase {
 		return array_merge( [
 			'sep'       => ', ',
 			'propsep'   => '<PROP>',
-			'manysep'   => '<MANY>',
+			'valuesep'  => '<MANY>',
 			'recordsep' => '<RCRD>',
 			'headersep' => ': ',
 			'name'      => false,

--- a/tests/phpunit/Unit/Formats/SRFHashTest.php
+++ b/tests/phpunit/Unit/Formats/SRFHashTest.php
@@ -185,4 +185,20 @@ class SRFHashTest extends TestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function testGetParamDefinitionsRemovesTitlesAndUsesHashNameMessage(): void {
+		$stub = new class {
+			public function setDefault( $value ) {
+			}
+		};
+		$definitions = $this->newInstance()->getParamDefinitions( [
+			'limit'   => clone $stub,
+			'link'    => clone $stub,
+			'headers' => clone $stub,
+		] );
+
+		$this->assertArrayNotHasKey( 'titles', $definitions );
+		$this->assertSame( 'srf_paramdesc_hashname', $definitions['name']['message'] );
+		$this->assertSame( [ 'manysep' ], $definitions['valuesep']['aliases'] );
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/466

The array and hash formats used `manysep` for the separator between the values of a multi-value property, while the core `list` format calls the same concept `valuesep`. The parameter is renamed for consistency, with `manysep` kept as an alias so existing queries keep working — the compromise proposed in the 2019 discussion, landing now that 6.0.0 is a major release anyway.

Deliberately untouched, so no wiki-side changes are needed:

* the message key `srf_paramdesc_manysep` and its 35+ translations (the definition references the message key explicitly); its qqq documentation now points at `valuesep`
* the `$srfgArrayManySep` configuration variable and the `$wgSrfgArraySepTextualFallbacks` cache key

A new unit test asserts the definition shape (`valuesep` present with the `manysep` alias, no standalone `manysep` definition); the existing separator-assignment tests are updated to the new processed-parameter key.

The second commit closes the remaining unit coverage gaps in the two printers: `getResultText()` end to end with multi-value properties (the value separator visible in real output) and the record-value branch, the real `deliverSingleValue()` (trim + character-reference decoding), `ArrayPrinter::createArray()`'s extension-absent path, and `HashPrinter::getParamDefinitions()`.

Out-of-scope observation while reading: `getCfgSepText()` still uses `\Revision::RAW` and `Article::getContent()`, both removed from MediaWiki core before the 1.43 minimum — the documented page-reference-separator feature would fatal if used. To be filed as its own issue.

After merge, the smw.org Help:Array format documentation needs the parameter rename.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; ask from @kghbln pointing at the issue; no revisions; diff not yet human-reviewed; PHPUnit not runnable in the authoring sandbox — CI verifies.</sub>
