### PR TITLE
fix(graph): guard against null node labels and skip-eligible page-type values

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,7 @@ Released on TBD.
 
 ### Bug Fixes
 
+* Fixed `graph` format: `htmlspecialchars()` deprecation notice (PHP 8.1+) when a node has no label, and a missing `skipNode` guard in `GraphPrinter::processResultRow()` that could create a node from a page-type value that should have been skipped ([1096](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1096)) (by [gesinn.it](https://gesinn.it))
 * Fixed `graph` format crash when more than 14 distinct edge predicates are used — the color palette now cycles instead of throwing an undefined array key error (by [gesinn.it](https://gesinn.it))
 * Fixed `array`/`hash` formats: `continue 2` skipping entire row when page titles are hidden, no-op `unset` in `SRFHash::getParamDefinitions`, uninitialized gap/title properties, loose equality comparisons for `SMW_HEADERS_*`, and missing `return true` in `SRFHash::createArray` ([1055](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1055)) (by [gesinn.it](https://gesinn.it))
 * Fixed `calendar` format: `leapJulian()` incorrectly returned false for astronomical year 0 (1 BC) and year −4 (5 BC) due to PHP's negative modulo semantics ([1056](https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1056)) (by [gesinn.it](https://gesinn.it))

--- a/src/Graph/GraphFormatter.php
+++ b/src/Graph/GraphFormatter.php
@@ -92,7 +92,7 @@ class GraphFormatter {
 		/** @var GraphNode $node */
 		foreach ( $nodes as $node ) {
 			$instance = $this;
-			$nodeLabel = htmlspecialchars( $node->getLabel() );
+			$nodeLabel = htmlspecialchars( $node->getLabel() ?? '' );
 
 			// take "displaytitle" as node-label if it is set
 			if ( $this->options->getNodeLabel() === GraphPrinter::NODELABEL_DISPLAYTITLE ) {

--- a/src/Graph/GraphPrinter.php
+++ b/src/Graph/GraphPrinter.php
@@ -242,7 +242,7 @@ class GraphPrinter extends ResultPrinter {
 						}
 					}
 				} elseif ( $showAsEdge ) {
-					if ( !$node && !$hasProperty ) {
+					if ( !$node && !$hasProperty && !$skipNode ) {
 						$node = new GraphNode( $objectText );
 						$node->setLabel( $object->getPreferredCaption() ?: $object->getText() );
 					} elseif ( $node && $objectText !== $node->getId() ) {

--- a/tests/phpunit/Unit/Graph/GraphFormatterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphFormatterTest.php
@@ -386,6 +386,27 @@ WRAPPED0
 	}
 
 	/**
+	 * @covers \SRF\Graph\GraphFormatter::buildGraph()
+	 *
+	 * Regression test for https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1096
+	 *
+	 * A node without a label (setLabel() never called, no fields) must not trigger a
+	 * htmlspecialchars(): Passing null to parameter #1 deprecation notice (PHP 8.1+).
+	 */
+	public function testBuildGraphHandlesNodeWithoutLabelAndWithoutFields(): void {
+		$params = self::BASE_PARAMS + [ 'graphfields' => false, 'graphfieldspages' => 'no' ];
+		$formatter = new GraphFormatter( new GraphOptions( $params ) );
+
+		$node = new GraphNode( 'Team:Lambda' );
+		// Do NOT call setLabel() — leaves the label null.
+
+		$formatter->buildGraph( [ $node ] );
+
+		// Must not throw/warn, and the node must still be rendered (via its ID/URL).
+		$this->assertStringContainsString( '"Team:Lambda"', $formatter->getGraph() );
+	}
+
+	/**
 	 * @covers \SRF\Graph\GraphFormatter::getGraphLegend()
 	 *
 	 * Covers line 257: the color counter resets to 0 after cycling through all 14

--- a/tests/phpunit/Unit/Graph/GraphPrinterTest.php
+++ b/tests/phpunit/Unit/Graph/GraphPrinterTest.php
@@ -113,6 +113,47 @@ class GraphPrinterTest extends TestCase {
 	}
 
 	/**
+	 * Regression test for https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1096
+	 *
+	 * When the first page-type printout's value has a property (so it is not eligible to
+	 * become the node) and a second page-type printout is seen (pageTypeSeen > 1, i.e.
+	 * skipNode=true), the node must NOT be created from that second, skip-eligible value.
+	 * Prior to the fix, the node-creation check inside the `showAsEdge` branch omitted the
+	 * `!$skipNode` guard applied to the first node-creation check, so it created a node
+	 * from data that should have been skipped.
+	 */
+	public function testProcessResultRowDoesNotCreateNodeFromSkippedPageTypeValue(): void {
+		$firstRequest = $this->makePrintRequest( '_wpg' );
+		$dvWithProperty = $this->getMockBuilder( SMWWikiPageValue::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$dvWithProperty->method( 'getWikiValue' )->willReturn( 'Subject' );
+		$dvWithProperty->method( 'getDisplayTitle' )->willReturn( 'Subject' );
+		$dvWithProperty->method( 'getProperty' )->willReturn( $this->createMock( \SMW\DIProperty::class ) );
+		$firstResultArray = $this->makeResultArray( $firstRequest, [ $dvWithProperty ] );
+
+		$secondRequest = $this->makePrintRequest( '_wpg' );
+		$dvSkippable = $this->getMockBuilder( SMWWikiPageValue::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$dvSkippable->method( 'getWikiValue' )->willReturn( 'ShouldBeSkipped' );
+		$dvSkippable->method( 'getDisplayTitle' )->willReturn( 'ShouldBeSkipped' );
+		$dvSkippable->method( 'getProperty' )->willReturn( null );
+		$secondResultArray = $this->makeResultArray( $secondRequest, [ $dvSkippable ] );
+
+		$printer = $this->makePrinter();
+		$ref = new ReflectionMethod( GraphPrinter::class, 'processResultRow' );
+		$ref->setAccessible( true );
+		$ref->invoke( $printer, [ $firstResultArray, $secondResultArray ] );
+
+		$nodesRef = new \ReflectionProperty( GraphPrinter::class, 'nodes' );
+		$nodesRef->setAccessible( true );
+		$nodes = $nodesRef->getValue( $printer );
+
+		$this->assertSame( [], $nodes, 'No node should be created when the only node-eligible value is skip-eligible.' );
+	}
+
+	/**
 	 * Page-type data values (_wpg) must still use getDisplayTitle(), falling back to getWikiValue().
 	 */
 	public function testProcessResultRowUsesDisplayTitleForPageType(): void {


### PR DESCRIPTION
## Summary
- Fixes the `htmlspecialchars(): Passing null to parameter #1` deprecation notice (PHP 8.1+) in `GraphFormatter::buildGraph()` when a `GraphNode` has no label — falls back to an empty string instead.
- Fixes a related logic gap in `GraphPrinter::processResultRow()`: the node-creation check inside the `showAsEdge` branch omitted the `!$skipNode` guard applied to the first node-creation check, so a page-type value that should have been skipped (e.g. a 2nd+ page-type printout beyond the first) could still become the node.
- Added regression tests for both fixes.

## Test plan
- [x] `make dev-test` (lint → PHPCS → Phan → PHPUnit → JS tests) passes with exit code 0
- [x] Full PHPUnit suite: 457 tests, 0 failures (455 pre-existing + 2 new regression tests)
- [x] Verified the `htmlspecialchars(): Passing null...` deprecation notice from #1096 no longer appears in test output after the fix
- [x] New `testBuildGraphHandlesNodeWithoutLabelAndWithoutFields` reproduces the original crash scenario
- [x] New `testProcessResultRowDoesNotCreateNodeFromSkippedPageTypeValue` reproduces the skipNode gap

Fixes #1096