### PR TITLE
ArrayFormat: fix undeclared class error, make Arrays visible to Phan

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -485,7 +485,7 @@ return [
             'PhanUndeclaredClass' => ['\\SRF\\ArrayFormat\\ArrayPrinter::__construct', '\\SRF\\ArrayFormat\\ArrayPrinter::getParamDefinitions', '\\SRF\\ArrayFormat\\ArrayPrinter::handleParameters'],
             'PhanUndeclaredClassConstant' => ['\\SRF\\ArrayFormat\\ArrayPrinter::createArray', '\\SRF\\ArrayFormat\\ArrayPrinter::getCfgSepText', '\\SRF\\ArrayFormat\\ArrayPrinter::getQueryMode'],
             'PhanUndeclaredClassInstanceof' => ['\\SRF\\ArrayFormat\\ArrayPrinter::getResultText'],
-            'PhanUndeclaredClassMethod' => ['\\SRF\\ArrayFormat\\ArrayPrinter::createArray', '\\SRF\\ArrayFormat\\ArrayPrinter::deliverPropertiesManyValues', '\\SRF\\ArrayFormat\\ArrayPrinter::getResultText'],
+            'PhanUndeclaredClassMethod' => ['\\SRF\\ArrayFormat\\ArrayPrinter::deliverPropertiesManyValues', '\\SRF\\ArrayFormat\\ArrayPrinter::getResultText'],
             'PhanUndeclaredConstant' => ['\\SRF\\ArrayFormat\\ArrayPrinter::deliverPropertiesManyValues'],
             'PhanUndeclaredExtendedClass' => ['src/ArrayFormat/ArrayPrinter.php'],
             'PhanUndeclaredMethod' => ['\\SRF\\ArrayFormat\\ArrayPrinter::getCfgSepText'],

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -20,4 +20,24 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 	]
 );
 
+// Make optional dependency extensions visible to Phan's type-checker: those
+// activated in the Makefile / ci.yml matrix. mediawiki-phan-config only adds
+// MW core and MW vendor to directory_list by default, never extensions/.
+// Without this, calls into an optional extension's classes either surface as
+// PhanUndeclaredClass* noise, or (for unqualified class references resolved
+// relative to the current namespace) are silently skipped by Phan instead of
+// being checked against the dependency's actual API.
+$IP = getenv( 'MW_INSTALL_PATH' ) !== false
+	? str_replace( '\\', '/', getenv( 'MW_INSTALL_PATH' ) )
+	: '../..';
+
+$dependencyExtensions = [
+	'Arrays',
+];
+
+foreach ( $dependencyExtensions as $ext ) {
+	$cfg['directory_list'][] = $IP . '/extensions/' . $ext;
+	$cfg['exclude_analysis_directory_list'][] = $IP . '/extensions/' . $ext;
+}
+
 return $cfg;

--- a/extensions.local.json
+++ b/extensions.local.json
@@ -10,6 +10,10 @@
       "version": "3.6.1",
       "repo": "wikimedia/mediawiki-extensions-ExternalData",
       "local_settings": "// ExternalData registers the <graphviz> tag too; it is loaded per-test only (see tests/phpunit/Integration/Graph/), not globally, to avoid colliding with Diagrams' handler for the same tag."
+    },
+    {
+      "name": "Arrays",
+      "version": "REL1_43"
     }
   ]
 }

--- a/src/ArrayFormat/ArrayPrinter.php
+++ b/src/ArrayFormat/ArrayPrinter.php
@@ -212,7 +212,7 @@ class ArrayPrinter extends ResultPrinter {
 
 		if ( defined( 'ExtArrays::VERSION' ) || class_exists( 'ExtArrays' ) ) {
 			$parser = MediaWikiServices::getInstance()->getParser();
-			ExtArrays::get( $parser )->createArray( $arrayId, $array );
+			\ExtArrays::get( $parser )->createArray( $arrayId, $array );
 			return true;
 		}
 

--- a/tests/phpunit/Unit/Formats/ExtArraysStub.php
+++ b/tests/phpunit/Unit/Formats/ExtArraysStub.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Minimal stand-in for the real Arrays extension's global ExtArrays class,
+ * matching its actual API (get(), instance createArray()). Loaded only when
+ * the real extension isn't installed, so tests exercise the same global,
+ * unqualified class reference that production code resolves against.
+ */
+class ExtArrays {
+
+	private static $instance;
+
+	public $created = [];
+
+	public static function &get( $parser ) {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	public function createArray( $arrayId, array $array = [] ) {
+		$this->created[$arrayId] = $array;
+	}
+
+}

--- a/tests/phpunit/Unit/Formats/SRFArrayTest.php
+++ b/tests/phpunit/Unit/Formats/SRFArrayTest.php
@@ -563,30 +563,14 @@ class SRFArrayTest extends TestCase {
 	 */
 	public function testCreateArrayCallsGlobalExtArraysWhenArraysExtensionInstalled(): void {
 		if ( !class_exists( 'ExtArrays' ) ) {
-			// Minimal stand-in for the real Arrays extension's global ExtArrays
-			// class, matching its actual API (get(), instance createArray()).
-			eval( <<<'PHP'
-				class ExtArrays {
-					private static $instance;
-					public $created = [];
-					public static function &get( $parser ) {
-						if ( self::$instance === null ) {
-							self::$instance = new self();
-						}
-						return self::$instance;
-					}
-					public function createArray( $arrayId, array $array = [] ) {
-						$this->created[$arrayId] = $array;
-					}
-				}
-				PHP
-			);
+			require_once __DIR__ . '/ExtArraysStub.php';
 		}
 
 		$instance = new class( 'array' ) extends ArrayPrinter {
 			public function createArrayPublic( $array ) {
 				return parent::createArray( $array );
 			}
+
 			public function set( string $property, $value ): void {
 				$this->$property = $value;
 			}

--- a/tests/phpunit/Unit/Formats/SRFArrayTest.php
+++ b/tests/phpunit/Unit/Formats/SRFArrayTest.php
@@ -553,4 +553,49 @@ class SRFArrayTest extends TestCase {
 		$this->assertFalse( $instance->createArrayPublic( [ 'a' ] ) );
 	}
 
+	/**
+	 * createArray() calls the global \ExtArrays class unqualified while this file
+	 * is itself namespaced (SRF\ArrayFormat). An unqualified class reference in a
+	 * static call is resolved by PHP relative to the current namespace, so without
+	 * the leading `\`, PHP looks for SRF\ArrayFormat\ExtArrays and throws an Error
+	 * when the Arrays extension is actually installed — regression for the
+	 * production crash reported when querying an inverse-array-name printout.
+	 */
+	public function testCreateArrayCallsGlobalExtArraysWhenArraysExtensionInstalled(): void {
+		if ( !class_exists( 'ExtArrays' ) ) {
+			// Minimal stand-in for the real Arrays extension's global ExtArrays
+			// class, matching its actual API (get(), instance createArray()).
+			eval( <<<'PHP'
+				class ExtArrays {
+					private static $instance;
+					public $created = [];
+					public static function &get( $parser ) {
+						if ( self::$instance === null ) {
+							self::$instance = new self();
+						}
+						return self::$instance;
+					}
+					public function createArray( $arrayId, array $array = [] ) {
+						$this->created[$arrayId] = $array;
+					}
+				}
+				PHP
+			);
+		}
+
+		$instance = new class( 'array' ) extends ArrayPrinter {
+			public function createArrayPublic( $array ) {
+				return parent::createArray( $array );
+			}
+			public function set( string $property, $value ): void {
+				$this->$property = $value;
+			}
+		};
+		$instance->set( 'mArrayName', 'myArr' );
+
+		$result = $instance->createArrayPublic( [ 'a', 'b' ] );
+
+		$this->assertTrue( $result );
+	}
+
 }


### PR DESCRIPTION
Fixes #1144

## Summary

- `ArrayPrinter::createArray()` calls the global `\ExtArrays` class unqualified while the file is namespaced (`SRF\ArrayFormat`). PHP resolves the unqualified static call relative to the current namespace, so it looks for `SRF\ArrayFormat\ExtArrays` instead of the global class — throwing an Error whenever the Arrays extension is actually installed. Regression from fb1a1e0e.
- Add `Arrays` as a CI dependency via `extensions.local.json` and widen `.phan/config.php` to include its source in Phan's scope (same pattern SemanticDrilldown/KnowledgeGraph/PageForms already use for `SemanticMediaWiki`), so Phan checks real usage against the dependency's actual API instead of silently skipping unknown classes.
- Regenerate `.phan/baseline.php` accordingly (only the `ArrayPrinter::createArray` entry for `PhanUndeclaredClassMethod` changes).

## Test plan

- Added `testCreateArrayCallsGlobalExtArraysWhenArraysExtensionInstalled`, which reproduces the exact production error before the fix (`Class "SRF\ArrayFormat\ExtArrays" not found`) and passes after it.
- Verified against SRF's own DCI container (MW 1.43, PHP 8.3, SMW 7.2.0 — the coverage/Phan matrix leg) with the real Arrays extension installed via `extensions.local.json`:
  - Phan: reproduces `PhanUndeclaredClassMethod ... \SRF\ArrayFormat\ExtArrays` before the fix, clean after.
  - Full PHPUnit suite: 574 tests, 1380 assertions, all green — no regressions.