### PR TITLE
fix filter data property chains

### DIFF
--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -368,7 +368,11 @@ class Filtered extends ResultPrinter {
 
 			if ( $printRequest->getData() instanceof PropertyValue ) {
 				$prConfig['property'] = $printRequest->getData()->getInceptiveProperty()->getKey();
-			}
+
+			// @see SMW\Query\Result\ResultArray -> getNextDataValue
+			} elseif ( $prConfig['mode'] === PrintRequest::PRINT_CHAIN ) {
+    			$prConfig['property']  = $printRequest->getData()->getLastPropertyChainValue()->getDataItem()->getKey();
+    		}
 
 			if ( filter_var( $printRequest->getParameter( 'hide' ), FILTER_VALIDATE_BOOLEAN ) ) {
 				$prConfig['hide'] = true;

--- a/formats/filtered/src/Filtered.php
+++ b/formats/filtered/src/Filtered.php
@@ -371,8 +371,8 @@ class Filtered extends ResultPrinter {
 
 			// @see SMW\Query\Result\ResultArray -> getNextDataValue
 			} elseif ( $prConfig['mode'] === PrintRequest::PRINT_CHAIN ) {
-    			$prConfig['property']  = $printRequest->getData()->getLastPropertyChainValue()->getDataItem()->getKey();
-    		}
+				$prConfig['property'] = $printRequest->getData()->getLastPropertyChainValue()->getDataItem()->getKey();
+			}
 
 			if ( filter_var( $printRequest->getParameter( 'hide' ), FILTER_VALIDATE_BOOLEAN ) ) {
 				$prConfig['hide'] = true;


### PR DESCRIPTION
Ensures 'property' key is defined with property chains in filter data. (`SRF\Filtered\Filtered -> getFilterHtml`)

- fixes https://github.com/SemanticMediaWiki/SemanticResultFormats/issues/1143